### PR TITLE
fix(state): normalize keys without backtracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to Lobster will be documented in this file.
 
 ## Unreleased
 
-- Normalize state keys in linear time even when untrusted input contains very long separator runs.
 - Honor cancellation and step timeouts in `gog.gmail.send` by terminating the gog process tree the same way `gog.gmail.search` already does.
 - Do not automatically retry a timed-out or failed `gog.gmail.send` step. Killing the local client cannot prove Gmail did not already accept the message.
 - Add first-class `openclaw.agent` workflow turns with configured agent, session, model, thinking, and timeout selection delegated to OpenClaw. Thanks to [@Stoff81](https://github.com/Stoff81) (Issue [#117](https://github.com/openclaw/lobster/issues/117)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Lobster will be documented in this file.
 
 ## Unreleased
 
+- Normalize state keys in linear time even when untrusted input contains very long separator runs.
 - Honor cancellation and step timeouts in `gog.gmail.send` by terminating the gog process tree the same way `gog.gmail.search` already does.
 - Do not automatically retry a timed-out or failed `gog.gmail.send` step. Killing the local client cannot prove Gmail did not already accept the message.
 - Add first-class `openclaw.agent` workflow turns with configured agent, session, model, thinking, and timeout selection delegated to OpenClaw. Thanks to [@Stoff81](https://github.com/Stoff81) (Issue [#117](https://github.com/openclaw/lobster/issues/117)).

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -27,11 +27,12 @@ export function defaultStateDir(env) {
 }
 
 export function keyToPath(stateDir, key) {
-	const safe = String(key)
+	let safe = String(key)
 		.toLowerCase()
 		.replace(/[^a-z0-9._-]+/g, "_")
-		.replace(/_+/g, "_")
-		.replace(/^_+|_+$/g, "");
+		.replace(/_+/g, "_");
+	if (safe.startsWith("_")) safe = safe.slice(1);
+	if (safe.endsWith("_")) safe = safe.slice(0, -1);
 	if (!safe) throw new Error("state key is empty/invalid");
 	return path.join(stateDir, `${safe}.json`);
 }

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -28,15 +28,20 @@ function streamOf(items) {
 	})();
 }
 
-test("state keys normalize long separator runs without changing filenames", () => {
+test("state key boundary trimming preserves normalized filenames", () => {
 	const tmp = path.join(os.tmpdir(), "lobster-state");
-	const separators = "_".repeat(100_000);
 
-	assert.equal(
-		keyToPath(tmp, `${separators}Demo KEY${separators}`),
-		path.join(tmp, "demo_key.json"),
-	);
-	assert.throws(() => keyToPath(tmp, separators), /state key is empty\/invalid/);
+	for (const [key, filename] of [
+		["_Demo KEY_", "demo_key.json"],
+		["___Demo KEY___", "demo_key.json"],
+		[" Demo KEY ", "demo_key.json"],
+		["-Demo KEY-", "-demo_key-.json"],
+		[".Demo KEY.", ".demo_key..json"],
+	]) {
+		assert.equal(keyToPath(tmp, key), path.join(tmp, filename));
+	}
+	assert.throws(() => keyToPath(tmp, "_"), /state key is empty\/invalid/);
+	assert.throws(() => keyToPath(tmp, "___"), /state key is empty\/invalid/);
 });
 
 test("state.set writes and state.get reads", async () => {

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -28,6 +28,17 @@ function streamOf(items) {
 	})();
 }
 
+test("state keys normalize long separator runs without changing filenames", () => {
+	const tmp = path.join(os.tmpdir(), "lobster-state");
+	const separators = "_".repeat(100_000);
+
+	assert.equal(
+		keyToPath(tmp, `${separators}Demo KEY${separators}`),
+		path.join(tmp, "demo_key.json"),
+	);
+	assert.throws(() => keyToPath(tmp, separators), /state key is empty\/invalid/);
+});
+
 test("state.set writes and state.get reads", async () => {
 	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-state-"));
 	const registry = createDefaultRegistry();


### PR DESCRIPTION
## What Problem This Solves

Fixes CodeQL alert #1 (`js/polynomial-redos`) by removing the flagged boundary-trim regular expression from state-key normalization.

## Why This Change Was Made

The preceding separator-collapse step already bounds each boundary run to one underscore, so this is implementation-shape scanner hardening rather than an exploit reproduction. State-key normalization now removes that guaranteed single boundary separator with direct string operations. The on-disk filename contract is unchanged.

## User Impact

No user-visible behavior change. State-key filenames and invalid empty-key handling remain unchanged.

## Evidence

- `pnpm exec oxfmt --check src/state/store.ts test/state.test.ts`
- `pnpm typecheck`
- `node --test dist/test/state.test.js`: 38 tests, 37 passed, 1 expected skip, 0 failed
- Full-suite retry reached the changed state suite successfully; four unrelated timing-sensitive cancellation tests failed on the local host.
- Added a boundary-case compatibility matrix covering collapsed underscores, normalized spaces, retained dots/dashes, and invalid all-separator keys.
- Exact-head CodeQL run 32455391192 passed both Actions and JavaScript/TypeScript analysis before the test-only proof clarification; the PR ref reported zero open alerts.
- Production LOC: +4/-3 (net +1) | Tests: +16/-0
