### PR TITLE
fix(runtime): keep process execution shell-free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to Lobster will be documented in this file.
 
 ## Unreleased
 
-- Keep environment-selected executable paths in direct process execution, never shell interpretation.
 - Honor cancellation and step timeouts in `gog.gmail.send` by terminating the gog process tree the same way `gog.gmail.search` already does.
 - Do not automatically retry a timed-out or failed `gog.gmail.send` step. Killing the local client cannot prove Gmail did not already accept the message.
 - Add first-class `openclaw.agent` workflow turns with configured agent, session, model, thinking, and timeout selection delegated to OpenClaw. Thanks to [@Stoff81](https://github.com/Stoff81) (Issue [#117](https://github.com/openclaw/lobster/issues/117)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Lobster will be documented in this file.
 
 ## Unreleased
 
+- Keep environment-selected executable paths in direct process execution, never shell interpretation.
 - Honor cancellation and step timeouts in `gog.gmail.send` by terminating the gog process tree the same way `gog.gmail.search` already does.
 - Do not automatically retry a timed-out or failed `gog.gmail.send` step. Killing the local client cannot prove Gmail did not already accept the message.
 - Add first-class `openclaw.agent` workflow turns with configured agent, session, model, thinking, and timeout selection delegated to OpenClaw. Thanks to [@Stoff81](https://github.com/Stoff81) (Issue [#117](https://github.com/openclaw/lobster/issues/117)).

--- a/src/abortable_process.ts
+++ b/src/abortable_process.ts
@@ -89,6 +89,7 @@ export function runAbortableProcess({
 		const child = spawn(command, argv, {
 			env,
 			cwd,
+			shell: false,
 			stdio: ["pipe", "pipe", "pipe"],
 			// Create a dedicated POSIX process group only when this runner owns a
 			// cancellation signal for it. Direct APIs without one must retain the

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -64,6 +64,32 @@ test("runAbortableProcess preserves UTF-8 characters split across pipe chunks", 
 	assert.equal(result.stdout, "€");
 });
 
+test(
+	"runAbortableProcess does not shell-interpret an executable path",
+	{ skip: process.platform === "win32" },
+	async () => {
+		const dir = await mkdtemp(join(tmpdir(), "lobster-process-path-"));
+		try {
+			const marker = join(dir, "injected");
+			const executable = join(dir, "node;touch injected");
+			await fsp.symlink(process.execPath, executable);
+
+			const result = await runAbortableProcess({
+				command: executable,
+				argv: ["-e", "process.stdout.write('ok')"],
+				cwd: dir,
+				env: process.env,
+				notFoundMessage: "node missing",
+			});
+
+			assert.equal(result.stdout, "ok");
+			assert.equal(await fileExists(marker), false);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	},
+);
+
 test("runAbortableProcess does not spawn when its signal is already aborted", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-pre-aborted-process-"));
 	try {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where environment-selected executable paths reached a process-launch boundary whose no-shell contract was implicit, causing CodeQL alert #7 (`js/shell-command-injection-from-environment`).

## Why This Change Was Made

The shared abortable process runner now explicitly disables shell interpretation for every caller. A regression test executes a path containing shell metacharacters and proves no injected command runs.

## User Impact

OpenClaw, gog, gh, and workflow executables selected through environment/config paths remain direct process launches with their argument vectors preserved.

## Evidence

- `pnpm exec oxfmt --check src/abortable_process.ts test/cancellation.test.ts`
- `pnpm typecheck`
- Focused `runAbortableProcess` tests: 3 passed, 1 platform skip, 0 failed
- Verified Node 26 child-process types/documentation: `spawn(..., { shell: false })` keeps command arguments out of shell interpretation.
- Exact-head CodeQL passed both Actions and JavaScript/TypeScript analysis; the PR ref reported zero open alerts.
- Production LOC: +1/-0 (net +1) | Tests: +26/-0
