### PR TITLE
fix(workflows): contain untrusted record keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Lobster will be documented in this file.
 
 ## Unreleased
 
+- Harden workflow result maps against prototype-named step IDs, keep test-only file paths out of generated command source, and safely encode Mermaid graph labels.
 - Honor cancellation and step timeouts in `gog.gmail.send` by terminating the gog process tree the same way `gog.gmail.search` already does.
 - Do not automatically retry a timed-out or failed `gog.gmail.send` step. Killing the local client cannot prove Gmail did not already accept the message.
 - Add first-class `openclaw.agent` workflow turns with configured agent, session, model, thinking, and timeout selection delegated to OpenClaw. Thanks to [@Stoff81](https://github.com/Stoff81) (Issue [#117](https://github.com/openclaw/lobster/issues/117)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to Lobster will be documented in this file.
 
 ## Unreleased
 
-- Harden workflow result maps against prototype-named step IDs, keep test-only file paths out of generated command source, and safely encode Mermaid graph labels.
 - Honor cancellation and step timeouts in `gog.gmail.send` by terminating the gog process tree the same way `gog.gmail.search` already does.
 - Do not automatically retry a timed-out or failed `gog.gmail.send` step. Killing the local client cannot prove Gmail did not already accept the message.
 - Add first-class `openclaw.agent` workflow turns with configured agent, session, model, thinking, and timeout selection delegated to OpenClaw. Thanks to [@Stoff81](https://github.com/Stoff81) (Issue [#117](https://github.com/openclaw/lobster/issues/117)).

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -197,6 +197,13 @@ type RunContext = {
 
 const NON_RETRYABLE_STEP_ERROR = Symbol("lobster.nonRetryableStepError");
 
+function createRecord<T>(source?: Record<string, T>): Record<string, T> {
+	const record = Object.create(null) as Record<string, T>;
+	if (!source) return record;
+	for (const [key, value] of Object.entries(source)) record[key] = value;
+	return record;
+}
+
 function markStepErrorNonRetryable(error: unknown): Error {
 	const normalized = error instanceof Error ? error : new Error(String(error));
 	Object.defineProperty(normalized, NON_RETRYABLE_STEP_ERROR, { value: true });
@@ -732,7 +739,7 @@ export function resolveWorkflowArgs(
 	argDefs: WorkflowFile["args"],
 	provided: Record<string, unknown> | undefined,
 ) {
-	const resolved: Record<string, unknown> = {};
+	const resolved = createRecord<unknown>();
 	if (argDefs) {
 		for (const [key, def] of Object.entries(argDefs)) {
 			if (def && typeof def === "object" && "default" in def) {
@@ -885,7 +892,7 @@ export async function runWorkflowFile({
 		const stepIndexById = new Map(steps.map((step, idx) => [step.id, idx]));
 		const results: Record<string, WorkflowStepResult> = resumeState?.steps
 			? cloneResults(resumeState.steps)
-			: {};
+			: createRecord();
 		const startIndex = resumeState?.resumeAtIndex ?? 0;
 
 		if (resumeState?.approvalStepId && typeof approved === "boolean") {
@@ -1142,7 +1149,7 @@ export async function runWorkflowFile({
 					}
 
 					const item = itemsRef[itemIdx];
-					const scopedResults: Record<string, WorkflowStepResult> = { ...results };
+					const scopedResults = createRecord(results);
 					scopedResults[itemVar] = {
 						id: itemVar,
 						json: item,
@@ -1224,7 +1231,9 @@ export async function runWorkflowFile({
 						}
 					}
 
-					const iterResult: Record<string, unknown> = { [itemVar]: item, [indexVar]: itemIdx };
+					const iterResult = createRecord<unknown>();
+					iterResult[itemVar] = item;
+					iterResult[indexVar] = itemIdx;
 					for (const subStep of step.steps) {
 						const subResult = scopedResults[subStep.id];
 						if (subResult && !subResult.skipped) {
@@ -1232,7 +1241,7 @@ export async function runWorkflowFile({
 								subResult.json !== undefined ? subResult.json : subResult.stdout;
 						}
 					}
-					iterationResults.push(iterResult);
+					iterationResults.push(Object.fromEntries(Object.entries(iterResult)));
 				}
 
 				const loopResult: WorkflowStepResult = {
@@ -1413,7 +1422,8 @@ export async function runWorkflowFile({
 									branchId: string;
 									result: WorkflowStepResult;
 								};
-								parallelBranchResults = { [winner.branchId]: winner.result };
+								parallelBranchResults = createRecord();
+								parallelBranchResults[winner.branchId] = winner.result;
 								branchLedgers.get(winner.branchId)?.release();
 							} else {
 								const settled = (await (timeoutPromise
@@ -1423,7 +1433,7 @@ export async function runWorkflowFile({
 									result: WorkflowStepResult;
 								}>[];
 
-								parallelBranchResults = {};
+								parallelBranchResults = createRecord();
 								for (const entry of settled) {
 									if (entry.status === "rejected") {
 										throw new Error(
@@ -1441,10 +1451,12 @@ export async function runWorkflowFile({
 							else await branchesSettled;
 						}
 
-						const merged: Record<string, unknown> = {};
-						for (const [branchId, branchResult] of Object.entries(parallelBranchResults ?? {})) {
-							merged[branchId] = branchResult.json;
-						}
+						const merged = Object.fromEntries(
+							Object.entries(parallelBranchResults ?? {}).map(([branchId, branchResult]) => [
+								branchId,
+								branchResult.json,
+							]),
+						);
 						result = {
 							id: step.id,
 							json: merged,
@@ -2018,7 +2030,7 @@ function dryRunWorkflow({
 			if (step.pause_ms) lines.push(`     pause_ms: ${step.pause_ms}`);
 			lines.push(`     sub-steps: ${step.steps.length}`);
 
-			const loopScopedResults = { ...results };
+			const loopScopedResults = createRecord(results);
 			loopScopedResults[dryItemVar] = { id: dryItemVar, json: { _placeholder: true } };
 			loopScopedResults[dryIndexVar] = { id: dryIndexVar, json: 0 };
 			for (let subIdx = 0; subIdx < step.steps.length; subIdx++) {
@@ -2449,7 +2461,7 @@ function mergeEnv(
 	args: Record<string, unknown>,
 	results: Record<string, WorkflowStepResult>,
 ) {
-	const env = { ...base } as Record<string, string | undefined>;
+	const env = createRecord(base);
 
 	// Expose resolved args as env vars so shell commands can safely reference them
 	// without embedding raw values into the command string.
@@ -2481,7 +2493,9 @@ function normalizeArgEnvKey(key: string): string | null {
 	if (!trimmed) return null;
 	// Keep it predictable for shells: uppercase and [A-Z0-9_]
 	const up = trimmed.toUpperCase();
-	const normalized = up.replace(/[^A-Z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+	let normalized = up.replace(/[^A-Z0-9]+/g, "_");
+	if (normalized.startsWith("_")) normalized = normalized.slice(1);
+	if (normalized.endsWith("_")) normalized = normalized.slice(0, -1);
 	return normalized || null;
 }
 
@@ -2527,8 +2541,8 @@ function resolveWorkflowStepArgs(
 	parentArgs: Record<string, unknown>,
 	results: Record<string, WorkflowStepResult>,
 ): Record<string, unknown> {
-	if (!workflowArgs) return {};
-	const resolved: Record<string, unknown> = {};
+	if (!workflowArgs) return createRecord();
+	const resolved = createRecord<unknown>();
 	for (const [key, value] of Object.entries(workflowArgs)) {
 		if (typeof value === "string") {
 			resolved[key] = resolveTemplate(value, parentArgs, results);
@@ -2541,7 +2555,7 @@ function resolveWorkflowStepArgs(
 
 function resolveArgsTemplate(input: string, args: Record<string, unknown>) {
 	return input.replace(/\$\{([A-Za-z0-9_-]+)\}/g, (match, key) => {
-		if (key in args) return String(args[key]);
+		if (Object.hasOwn(args, key)) return String(args[key]);
 		return match;
 	});
 }
@@ -3032,7 +3046,7 @@ function toOutputItems(result: WorkflowStepResult | undefined) {
 }
 
 function cloneResults(results: Record<string, WorkflowStepResult>) {
-	const out: Record<string, WorkflowStepResult> = {};
+	const out = createRecord<WorkflowStepResult>();
 	for (const [key, value] of Object.entries(results)) {
 		out[key] = { ...value };
 	}

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -2494,8 +2494,11 @@ function normalizeArgEnvKey(key: string): string | null {
 	// Keep it predictable for shells: uppercase and [A-Z0-9_]
 	const up = trimmed.toUpperCase();
 	let normalized = up.replace(/[^A-Z0-9]+/g, "_");
-	if (normalized.startsWith("_")) normalized = normalized.slice(1);
-	if (normalized.endsWith("_")) normalized = normalized.slice(0, -1);
+	let start = 0;
+	while (normalized[start] === "_") start++;
+	let end = normalized.length;
+	while (end > start && normalized[end - 1] === "_") end--;
+	normalized = normalized.slice(start, end);
 	return normalized || null;
 }
 

--- a/src/workflows/graph.ts
+++ b/src/workflows/graph.ts
@@ -23,7 +23,7 @@ type RenderGraphParams = {
 
 function resolveArgsTemplate(input: string, args: Record<string, unknown>) {
 	return input.replace(/\$\{([A-Za-z0-9_-]+)\}/g, (match, key) => {
-		if (key in args) return String(args[key]);
+		if (Object.hasOwn(args, key)) return String(args[key]);
 		return match;
 	});
 }
@@ -163,7 +163,14 @@ function sanitizeMermaidId(id: string) {
 }
 
 function escapeMermaidLabel(value: string) {
-	return value.replace(/"/g, '\\"');
+	const entities = {
+		"&": "&amp;",
+		'"': "&quot;",
+		"<": "&lt;",
+		">": "&gt;",
+		"|": "&#124;",
+	} as const;
+	return value.replace(/[&"<>|]/g, (character) => entities[character as keyof typeof entities]);
 }
 
 function renderMermaid(nodes: GraphNode[], edges: GraphEdge[]) {

--- a/test/workflow_args_env.test.ts
+++ b/test/workflow_args_env.test.ts
@@ -11,13 +11,14 @@ test("workflow file exposes args as LOBSTER_ARG_* env vars (safe for quotes)", a
 		name: "args-env",
 		args: {
 			text: { default: "" },
+			__edge__key__: { default: "" },
 		},
 		steps: [
 			{
 				id: "echo",
 				// Avoid embedding the arg into the shell command; read from env instead.
 				command:
-					'node -e "process.stdout.write(JSON.stringify({text: process.env.LOBSTER_ARG_TEXT}))"',
+					'node -e "process.stdout.write(JSON.stringify({text: process.env.LOBSTER_ARG_TEXT, edge: process.env.LOBSTER_ARG_EDGE_KEY}))"',
 			},
 		],
 	};
@@ -29,10 +30,11 @@ test("workflow file exposes args as LOBSTER_ARG_* env vars (safe for quotes)", a
 
 	const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
 	const text = 'hello "world" $HOME `backticks` $(whoami)';
+	const edge = "preserved";
 
 	const result = await runWorkflowFile({
 		filePath,
-		args: { text },
+		args: { text, __edge__key__: edge },
 		ctx: {
 			stdin: process.stdin,
 			stdout: process.stdout,
@@ -43,5 +45,5 @@ test("workflow file exposes args as LOBSTER_ARG_* env vars (safe for quotes)", a
 	});
 
 	assert.equal(result.status, "ok");
-	assert.deepEqual(result.output, [{ text }]);
+	assert.deepEqual(result.output, [{ text, edge }]);
 });

--- a/test/workflow_file.test.ts
+++ b/test/workflow_file.test.ts
@@ -16,6 +16,11 @@ function streamOf(items: unknown[]) {
 	})();
 }
 
+const APPEND_EFFECT_AND_WAIT =
+	"node -e \"require('fs').appendFileSync(process.env.LOBSTER_TEST_EFFECT_PATH, 'run\\n'); setInterval(() => {}, 1000)\"";
+const COUNT_ATTEMPTS_AND_RETRY =
+	"node -e \"const fs=require('fs'); const file=process.env.LOBSTER_TEST_ATTEMPTS_PATH; const attempt=fs.existsSync(file) ? Number(fs.readFileSync(file, 'utf8')) : 0; fs.writeFileSync(file, String(attempt + 1)); if (attempt === 0) setInterval(() => {}, 1000); else process.stdout.write('retried');\"";
+
 test("workflow file runs with approval and resume", async () => {
 	const workflow = {
 		name: "sample",
@@ -226,7 +231,8 @@ test("direct workflow resume consumes its capability after cancellation starts a
 				},
 				{
 					id: "effect",
-					run: `node -e "require('fs').appendFileSync(process.argv[1], 'run\\n'); setInterval(() => {}, 1000)" ${JSON.stringify(effectPath)}`,
+					run: APPEND_EFFECT_AND_WAIT,
+					env: { LOBSTER_TEST_EFFECT_PATH: effectPath },
 					condition: "$approve.approved",
 				},
 			],
@@ -397,7 +403,8 @@ test("workflow resume consumes its capability after a step timeout starts an eff
 				},
 				{
 					id: "effect",
-					run: `node -e "require('fs').appendFileSync(process.argv[1], 'run\\n'); setInterval(() => {}, 1000)" ${JSON.stringify(effectPath)}`,
+					run: APPEND_EFFECT_AND_WAIT,
+					env: { LOBSTER_TEST_EFFECT_PATH: effectPath },
 					condition: "$approve.approved",
 					timeout_ms: 1500,
 				},
@@ -475,7 +482,8 @@ test("workflow resume applies on_error after a timed-out effect", async () => {
 				},
 				{
 					id: "effect",
-					run: `node -e "require('fs').appendFileSync(process.argv[1], 'run\\n'); setInterval(() => {}, 1000)" ${JSON.stringify(effectPath)}`,
+					run: APPEND_EFFECT_AND_WAIT,
+					env: { LOBSTER_TEST_EFFECT_PATH: effectPath },
 					condition: "$approve.approved",
 					timeout_ms: 1500,
 					on_error: "continue",
@@ -536,7 +544,8 @@ test("workflow resume retries a timed-out effect before consuming its capability
 				},
 				{
 					id: "effect",
-					run: `node -e "const fs=require('fs'); const file=process.argv[1]; const attempt=fs.existsSync(file) ? Number(fs.readFileSync(file, 'utf8')) : 0; fs.writeFileSync(file, String(attempt + 1)); if (attempt === 0) setInterval(() => {}, 1000); else process.stdout.write('retried');" ${JSON.stringify(attemptsPath)}`,
+					run: COUNT_ATTEMPTS_AND_RETRY,
+					env: { LOBSTER_TEST_ATTEMPTS_PATH: attemptsPath },
 					condition: "$approve.approved",
 					timeout_ms: 1500,
 					retry: { max: 2, delay_ms: 10 },
@@ -703,7 +712,8 @@ test("workflow resume consumes its capability after a parallel timeout starts an
 						branches: [
 							{
 								id: "side-effect",
-								run: `node -e "require('fs').appendFileSync(process.argv[1], 'run\\n'); setInterval(() => {}, 1000)" ${JSON.stringify(effectPath)}`,
+								run: APPEND_EFFECT_AND_WAIT,
+								env: { LOBSTER_TEST_EFFECT_PATH: effectPath },
 							},
 						],
 					},
@@ -904,6 +914,64 @@ test("workflow file input steps pause and resume with structured responses", asy
 
 	assert.equal(resumed.status, "ok");
 	assert.deepEqual(resumed.output, [{ decision: "approve", subject: "hello" }]);
+});
+
+test("workflow input resume contains prototype-named step ids", async () => {
+	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-workflow-prototype-step-"));
+	const stateDir = path.join(tmpDir, "state");
+	const filePath = path.join(tmpDir, "workflow.lobster");
+	const objectPrototype = Object.prototype as Record<string, unknown>;
+	try {
+		await fsp.writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{
+						id: "__proto__",
+						input: {
+							prompt: "Continue?",
+							responseSchema: {
+								type: "object",
+								properties: { decision: { type: "string" } },
+								required: ["decision"],
+							},
+						},
+					},
+					{
+						id: "finish",
+						run: 'node -e "process.stdout.write(JSON.stringify({decision:process.env.DECISION}))"',
+						env: { DECISION: "$__proto__.response.decision" },
+					},
+				],
+			}),
+			"utf8",
+		);
+		const ctx = {
+			stdin: process.stdin,
+			stdout: process.stdout,
+			stderr: process.stderr,
+			env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+			mode: "tool" as const,
+		};
+
+		const first = await runWorkflowFile({ filePath, ctx });
+		const payload = decodeResumeToken(first.requiresInput?.resumeToken ?? "");
+		assert.equal(payload.kind, "workflow-file");
+		const resumed = await runWorkflowFile({
+			filePath,
+			ctx,
+			resume: payload,
+			response: { decision: "approve" },
+		});
+
+		assert.equal(Object.hasOwn(objectPrototype, "response"), false);
+		assert.equal(Object.hasOwn(objectPrototype, "subject"), false);
+		assert.deepEqual(resumed.output, [{ decision: "approve" }]);
+	} finally {
+		delete objectPrototype.response;
+		delete objectPrototype.subject;
+		await fsp.rm(tmpDir, { recursive: true, force: true });
+	}
 });
 
 test("workflow pipeline command input pauses and resumes the same pipeline step", async () => {

--- a/test/workflow_graph.test.ts
+++ b/test/workflow_graph.test.ts
@@ -36,14 +36,26 @@ test("workflow graph renderer outputs mermaid nodes and labeled edges", () => {
 	assert.match(output, /confirm\{"confirm\\napproval gate"\}/);
 	assert.match(
 		output,
-		/advice\["advice\\npipeline: llm\.invoke --prompt \\"Summarize this weather\\""\]/,
+		/advice\["advice\\npipeline: llm\.invoke --prompt &quot;Summarize this weather&quot;"\]/,
 	);
 	assert.match(output, /fetch -->\|stdin\| confirm/);
 	assert.match(output, /fetch -->\|stdin\| advice/);
 	assert.match(
 		output,
-		/confirm -->\|when: \$confirm\.approved && \$fetch\.json\.temp > 70\| advice/,
+		/confirm -->\|when: \$confirm\.approved &amp;&amp; \$fetch\.json\.temp &gt; 70\| advice/,
 	);
+});
+
+test("workflow graph renderer contains Mermaid metacharacters in labels", () => {
+	const output = renderWorkflowGraph({
+		workflow: {
+			steps: [{ id: "unsafe", run: 'echo \\"quoted" | next <tag>' }],
+		},
+		format: "mermaid",
+	});
+
+	assert.match(output, /echo \\&quot;quoted&quot; &#124; next &lt;tag&gt;/);
+	assert.doesNotMatch(output, /"quoted"/);
 });
 
 test("workflow graph renderer outputs dot with approval shape", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes workflow inputs that could use prototype-named keys, unsafe test-only command construction, or Mermaid metacharacters to escape their intended data boundaries. This retires CodeQL alerts #2-#6, #8, and #9.

## Why This Change Was Made

Workflow-owned dictionaries now use prototype-less records internally and convert back to plain objects only at output boundaries. Test fixture paths travel through workflow environment values instead of generated JavaScript source. Mermaid labels use entity encoding rather than partial backslash escaping.

## User Impact

Workflow step IDs, loop variables, arguments, and branch IDs remain fully supported even when they match inherited object names. Graph output renders quotes, operators, pipes, and tags as label text instead of Mermaid syntax.

## Evidence

- `pnpm exec oxfmt --check src/workflows/file.ts src/workflows/graph.ts test/workflow_args_env.test.ts test/workflow_file.test.ts test/workflow_graph.test.ts`
- `pnpm typecheck`
- Workflow args/file + graph suites: 38 passed, 0 failed
- Added a real pause/resume regression for step id `__proto__`, a repeated-edge-underscore argument env regression, and a Mermaid metacharacter containment regression.
- Exact-head CodeQL run 32456386071 passed both Actions and JavaScript/TypeScript analysis at `c6bc49c9957d1a60817577405f7c7b1d28729017`; the PR ref reported zero open alerts.
- Repo-wide `pnpm lint` remains blocked by the pre-existing unrelated unused `signal` at `src/commands/stdlib/llm_invoke.ts:1065`; no touched-file lint finding.
- Production LOC: +44/-20 (net +24), justified by the shared prototype-safe record boundary, compatibility-preserving linear env-key normalization, and complete graph encoding | Tests: +92/-10
