### PR TITLE
fix(runtime): separate shell process execution

### DIFF
--- a/src/abortable_process.ts
+++ b/src/abortable_process.ts
@@ -1,4 +1,5 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess, type SpawnOptionsWithoutStdio } from "node:child_process";
+import { resolveInlineShellCommand } from "./shell.js";
 
 const ABORT_FORCE_KILL_AFTER_MS = 250;
 const forceTerminationCallbacks = new WeakMap<AbortSignal, Set<() => void>>();
@@ -9,9 +10,7 @@ type ProcessResult = {
 	code: number | null;
 };
 
-type RunAbortableProcessOptions = {
-	command: string;
-	argv: string[];
+type RunAbortableOptions = {
 	env: NodeJS.ProcessEnv;
 	cwd?: string;
 	stdin?: string | null;
@@ -22,6 +21,12 @@ type RunAbortableProcessOptions = {
 	outputLimitMessage?: string;
 	notFoundMessage: string;
 };
+
+type RunAbortableProcessOptions = RunAbortableOptions &
+	(
+		| { command: string; argv: string[]; shellCommand?: never }
+		| { shellCommand: string; command?: never; argv?: never }
+	);
 
 export function forceTerminateAbortableProcesses(signal: AbortSignal) {
 	for (const terminate of forceTerminationCallbacks.get(signal) ?? []) terminate();
@@ -59,19 +64,18 @@ function terminateProcessTree(child: ChildProcess, signal: NodeJS.Signals): Prom
 	return Promise.resolve();
 }
 
-export function runAbortableProcess({
-	command,
-	argv,
-	env,
-	cwd,
-	stdin,
-	signal,
-	forceTerminationSignal,
-	killSignal,
-	maxOutputBytes,
-	outputLimitMessage,
-	notFoundMessage,
-}: RunAbortableProcessOptions): Promise<ProcessResult> {
+export function runAbortableProcess(options: RunAbortableProcessOptions): Promise<ProcessResult> {
+	const {
+		env,
+		cwd,
+		stdin,
+		signal,
+		forceTerminationSignal,
+		killSignal,
+		maxOutputBytes,
+		outputLimitMessage,
+		notFoundMessage,
+	} = options;
 	return new Promise((resolve, reject) => {
 		if (
 			maxOutputBytes !== undefined &&
@@ -86,16 +90,25 @@ export function runAbortableProcess({
 			reject(err);
 			return;
 		}
-		const child = spawn(command, argv, {
+		const spawnOptions: SpawnOptionsWithoutStdio = {
 			env,
 			cwd,
 			shell: false,
-			stdio: ["pipe", "pipe", "pipe"],
+			stdio: "pipe",
 			// Create a dedicated POSIX process group only when this runner owns a
 			// cancellation signal for it. Direct APIs without one must retain the
 			// caller's terminal process group so Ctrl-C still reaches their child.
 			detached: process.platform !== "win32" && signal !== undefined,
-		});
+		};
+		// Keep direct argv and shell command dataflow at distinct spawn sites.
+		// Merging them makes shell interpretation leak into direct executable callers.
+		const child =
+			"shellCommand" in options
+				? (() => {
+						const shell = resolveInlineShellCommand({ command: options.shellCommand, env });
+						return spawn(shell.command, shell.argv, spawnOptions);
+					})()
+				: spawn(options.command, options.argv, spawnOptions);
 
 		let stdout = "";
 		let stderr = "";

--- a/src/commands/stdlib/exec.ts
+++ b/src/commands/stdlib/exec.ts
@@ -1,5 +1,4 @@
 import { runAbortableProcess } from "../../abortable_process.js";
-import { resolveInlineShellCommand } from "../../shell.js";
 
 export const execCommand = {
 	name: "exec",
@@ -104,8 +103,18 @@ async function runProcess(command, argv, { env, cwd, stdin, signal, forceTermina
 }
 
 function runShellLine(commandLine, { env, cwd, stdin, signal, forceTerminationSignal }) {
-	const shell = resolveInlineShellCommand({ command: commandLine, env });
-	return runProcess(shell.command, shell.argv, { env, cwd, stdin, signal, forceTerminationSignal });
+	return runAbortableProcess({
+		shellCommand: commandLine,
+		env,
+		cwd,
+		stdin,
+		signal,
+		forceTerminationSignal,
+		notFoundMessage: "exec shell not found; check LOBSTER_SHELL or ComSpec",
+	}).then(({ stdout, stderr, code }) => {
+		if (code === 0) return { stdout, stderr };
+		throw new Error(`exec failed (${code}): ${stderr.trim() || stdout.trim() || commandLine}`);
+	});
 }
 
 function encodeStdin(items, mode) {

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -23,7 +23,6 @@ import {
 	writeStateJson,
 } from "../state/store.js";
 import { readLineFromStream } from "../read_line.js";
-import { resolveInlineShellCommand } from "../shell.js";
 import { compileCached } from "../validation.js";
 import {
 	createLlmSpendLedger,
@@ -3533,17 +3532,15 @@ async function runShellCommand({
 }) {
 	signal?.throwIfAborted();
 	signal?.throwIfAborted();
-	const shell = resolveInlineShellCommand({ command, env });
 	const { stdout, stderr, code } = await runAbortableProcess({
-		command: shell.command,
-		argv: shell.argv,
+		shellCommand: command,
 		env,
 		cwd,
 		stdin,
 		signal,
 		forceTerminationSignal,
 		killSignal,
-		notFoundMessage: `workflow command not found: ${shell.command}`,
+		notFoundMessage: "workflow shell not found; check LOBSTER_SHELL or ComSpec",
 	});
 	if (code === 0) return { stdout, stderr };
 	throw new Error(


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #139. Main-branch CodeQL run 32456399937 retired alert #7 but opened replacement alert #10 (`js/shell-command-injection-from-environment`) at the same shared process boundary.

## Why This Change Was Made

The shared runner accepted both direct executable argv and pre-resolved shell argv through one generic `spawn(command, argv)` site. CodeQL correctly merged absolute paths from direct OpenClaw test invocations into the intentional shell-command sink.

The runner now uses a discriminated execution contract with distinct direct and shell spawn sites while retaining one cancellation, output-limit, and process-tree lifecycle.

## User Impact

Direct commands remain argv-based and shell-free. `exec --shell` and workflow shell steps keep their existing shell behavior, overrides, cancellation, and error handling.

## Evidence

- `pnpm exec oxfmt --check src/abortable_process.ts src/commands/stdlib/exec.ts src/workflows/file.ts`
- `pnpm typecheck`
- OpenClaw agent, direct exec, shell exec, workflow, and stdin suites: 41 passed, 0 failed
- Focused process/cancellation suite: 4 passed, 1 platform skip, 0 failed
- Official CodeQL CLI 2.26.3 with `codeql/javascript-queries@2.4.3`: current main reproduced 9 query paths; exact head produced 0
- `git diff --check`
- Production LOC: +47/-28 (net +19), justified by the explicit direct-vs-shell execution ownership boundary
