### PR TITLE
ci: add Node 24 build and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint-workflows:
+    name: Lint workflows
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Lint workflows
+        uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
+
+  check:
+    name: Node 24 check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          run_install: false
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint and check formatting
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Lobster will be documented in this file.
 
 ## Unreleased
 
+- Run Node 24 CI on pull requests and pushes to `main`, checking workflow syntax, frozen dependency installation, build, types, formatting, lint, and tests.
 - Refresh development tooling and the `fast-uri` override, align pnpm on 11.24.0, and update GitHub Actions.
 - Honor cancellation and step timeouts in `gog.gmail.send` by terminating the gog process tree the same way `gog.gmail.search` already does.
 - Do not automatically retry a timed-out or failed `gog.gmail.send` step. Killing the local client cannot prove Gmail did not already accept the message.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Lobster will be documented in this file.
 ## Unreleased
 
 - Run Node 24 CI on pull requests and pushes to `main`, checking workflow syntax, frozen dependency installation, build, types, formatting, lint, and tests.
+- Preserve a replacement state lock when the filesystem reuses the stale lock's inode, preventing overlapping state writers.
 - Refresh development tooling and the `fast-uri` override, align pnpm on 11.24.0, and update GitHub Actions.
 - Honor cancellation and step timeouts in `gog.gmail.send` by terminating the gog process tree the same way `gog.gmail.search` already does.
 - Do not automatically retry a timed-out or failed `gog.gmail.send` step. Killing the local client cannot prove Gmail did not already accept the message.

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -267,11 +267,12 @@ async function reclaimOrphanedStateLock(lockPath: string) {
 		throw err;
 	}
 
+	const ownerPath = path.join(lockPath, "owner");
+	let observedOwner: string | undefined;
 	let stale = false;
 	try {
-		const ownerPath = path.join(lockPath, "owner");
-		const ownerText = (await fsp.readFile(ownerPath, "utf8")).trim();
-		const owner = parseStateLockOwner(ownerText);
+		observedOwner = await fsp.readFile(ownerPath, "utf8");
+		const owner = parseStateLockOwner(observedOwner);
 		if (owner && isProcessAlive(owner.pid)) {
 			const processStartIdentity = await readProcessStartIdentity(owner.pid);
 			if (owner.processStartIdentity && processStartIdentity) {
@@ -314,6 +315,14 @@ async function reclaimOrphanedStateLock(lockPath: string) {
 		if (currentLock.dev !== observedLock.dev || currentLock.ino !== observedLock.ino) {
 			return false;
 		}
+		// A replacement directory can reuse the inode; its owner must still match too.
+		let currentOwner: string | undefined;
+		try {
+			currentOwner = await fsp.readFile(ownerPath, "utf8");
+		} catch (err: any) {
+			if (err?.code !== "ENOENT") throw err;
+		}
+		if (currentOwner !== observedOwner) return false;
 		await fsp.rm(lockPath, { recursive: true, force: true });
 	} finally {
 		// If the path changed before the reclamation marker was claimed, leave the

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -837,20 +837,23 @@ test(
 	},
 );
 
-test("withFileLock does not reclaim a replacement lock after observing a stale one", async () => {
+test("withFileLock does not reclaim a replacement lock when its inode is reused", async () => {
 	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-state-lock-replacement-"));
 	const filePath = path.join(tmp, "snapshot.json");
 	const lockPath = `${filePath}.lock`;
 	await fsp.mkdir(lockPath);
-	await fsp.writeFile(path.join(lockPath, "owner"), `${process.pid}:0:stale-owner\n`, "utf8");
+	await fsp.writeFile(path.join(lockPath, "owner"), "2147483647::stale-owner\n", "utf8");
 	const staleAt = new Date(Date.now() - 10_000);
 	await fsp.utimes(lockPath, staleAt, staleAt);
 	await fsp.utimes(path.join(lockPath, "owner"), staleAt, staleAt);
 
 	const originalReadFile = fsp.readFile;
+	const originalLstat = fsp.lstat;
+	const staleLock = await originalLstat(lockPath);
 	let replaced = false;
 	let replacementActive = false;
 	let overlap = false;
+	let original: Promise<void> | undefined;
 	let replacement: Promise<void> | undefined;
 	let releaseReplacement!: () => void;
 	const replacementReleased = new Promise<void>((resolve) => {
@@ -859,6 +862,23 @@ test("withFileLock does not reclaim a replacement lock after observing a stale o
 	let replacementStarted!: () => void;
 	const replacementEntered = new Promise<void>((resolve) => {
 		replacementStarted = resolve;
+	});
+	let markReplacementObserved!: () => void;
+	const replacementObserved = new Promise<void>((resolve) => {
+		markReplacementObserved = resolve;
+	});
+
+	Object.defineProperty(fsp, "lstat", {
+		configurable: true,
+		writable: true,
+		async value(...args: Parameters<typeof fsp.lstat>) {
+			const stat = await originalLstat(...args);
+			if (replaced && String(args[0]) === lockPath) {
+				// Linux can recycle a deleted directory's inode for its replacement.
+				Object.assign(stat, { dev: staleLock.dev, ino: staleLock.ino });
+			}
+			return stat;
+		},
 	});
 
 	Object.defineProperty(fsp, "readFile", {
@@ -882,25 +902,34 @@ test("withFileLock does not reclaim a replacement lock after observing a stale o
 					},
 				});
 				await replacementEntered;
+			} else if (replacementActive && String(filePathArg) === path.join(lockPath, "owner")) {
+				markReplacementObserved();
 			}
 			return result;
 		},
 	});
 
 	try {
-		const original = withFileLock({
+		original = withFileLock({
 			filePath,
 			task: async () => {
 				if (replacementActive) overlap = true;
 			},
 		});
 		await replacementEntered;
-		await new Promise((resolve) => setTimeout(resolve, 25));
+		await Promise.race([original, replacementObserved]);
 		assert.equal(overlap, false, "the stale reclaimer must not enter beside the replacement");
 		releaseReplacement();
 		if (!replacement) throw new Error("replacement lock did not start");
 		await Promise.all([original, replacement]);
 	} finally {
+		releaseReplacement();
+		await Promise.allSettled([original, replacement]);
+		Object.defineProperty(fsp, "lstat", {
+			configurable: true,
+			writable: true,
+			value: originalLstat,
+		});
 		Object.defineProperty(fsp, "readFile", {
 			configurable: true,
 			writable: true,


### PR DESCRIPTION
## Why

Lobster has release and maintenance workflows, but no automatic build/test workflow for pull requests or pushes to main. Changes such as #142 therefore had no routine CI gate before merging.

## Changes

Add a minimal Ubuntu/Node 24 CI workflow that runs `pnpm install --frozen-lockfile`, build, typecheck, lint (including the existing format check), and the full test suite. A separate job checks all workflows with actionlint.

Follow the sibling libterminal CI conventions: action SHAs pinned with version comments, read-only repository permissions, bounded job timeouts, pnpm's version from `package.json`, a lockfile-keyed pnpm cache, and concurrency that cancels superseded PR runs without cancelling main runs. Add an Unreleased changelog entry. Release and publishing workflows are unchanged.

The first Linux CI run exposed a real state-lock race: a deleted directory's device/inode identity can be reused by a replacement lock. The stale-lock reclaimer checked only that identity, so it could remove a live replacement and let two state writers overlap. A separate fix commit rechecks the observed owner token before removal. The strengthened regression forces inode reuse on every platform and synchronizes on lock observation instead of a fixed sleep.

## Validation

- Local actionlint 1.7.12 passes for all workflows; `git diff --check` passes.
- Node 24.20.0 / pnpm 11.24.0: frozen install, build, typecheck, and lint/format checks pass. Lint retains existing non-fatal warnings.
- The built `bin/lobster.js` ran a real JSON pipeline successfully in tool mode.
- Codex autoreview completed with no blocking findings.
- The inode-reuse reproduction fails against the original built implementation and passes after the fix; the deterministic regression test passes locally.
- The [first Linux CI run](https://github.com/openclaw/lobster/actions/runs/33187391502) passed 540 of 541 tests and exposed the lock race above.
- [Final CI run](https://github.com/openclaw/lobster/actions/runs/33188123742) on `d901d9f57a64d4211aef27a06ef412c115e944cd` passes both jobs: workflow lint and Node 24 frozen install/build/typecheck/lint/format/tests. All **541 tests pass**, with **0 failures, 0 cancellations, and 0 skips**, in 35.73 seconds of test execution.
- The heavily loaded local Mac's full suite was not green: it reported three timing-related failures, one cancellation, and three platform skips. A focused rerun passed the replacement-lock regression and two of those failures; the cancellation fixture still failed during cleanup. All of these tests pass on Linux CI. Local build, typecheck, lint/format, actionlint, and the focused lock regression pass after the fix.

Do not merge as part of this task.
