### PR TITLE
fix(sdk): honor abort signal in exec and shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Lobster will be documented in this file.
 
 ## Unreleased
 
+- Honor SDK cancellation in `exec()` and shell commands, including constructor signals on run, clone, and resume. Thanks to [@SebTardif](https://github.com/SebTardif) (PR [#144](https://github.com/openclaw/lobster/pull/144)).
+
 - Run Node 24 CI on pull requests and pushes to `main`, checking workflow syntax, frozen dependency installation, build, types, formatting, lint, and tests.
 - Preserve a replacement state lock when the filesystem reuses the stale lock's inode, preventing overlapping state writers.
 - Refresh development tooling and the `fast-uri` override, align pnpm on 11.24.0, and update GitHub Actions.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,29 @@ From this folder:
 
 - OpenClaw integration: ship as an optional OpenClaw plugin tool.
 
+## SDK cancellation
+
+Pass an `AbortSignal` to `new Lobster({ signal })` to cancel SDK `exec()` stages,
+including `exec(command, { shell: true })`. The signal is retained by `clone()`
+and forwarded when a pipeline resumes. Aborting terminates the running child
+process tree before `run()` or `resume()` returns an error result containing the
+abort reason. A signal that is already aborted prevents the command from starting.
+
+```js
+import { Lobster, exec } from '@clawdbot/lobster';
+
+const controller = new AbortController();
+const pending = new Lobster({ signal: controller.signal })
+  .pipe(exec('node long-task.js', { json: false }))
+  .run();
+// When the host needs to stop the command:
+controller.abort(new Error('Host cancelled the command'));
+const result = await pending;
+```
+
+Custom stages receive the signal as `ctx.signal` and must cooperate with it to
+cancel their own work.
+
 ## Workflow files
 
 Lobster workflow files are meant to read like small scripts:

--- a/src/sdk/Lobster.ts
+++ b/src/sdk/Lobster.ts
@@ -47,6 +47,7 @@ type SdkCommandInputResumeState = {
  * @typedef {Object} LobsterOptions
  * @property {Object} [env] - Environment variables
  * @property {string} [stateDir] - State directory override
+ * @property {AbortSignal} [signal] - Abort signal forwarded to pipeline stages
  */
 
 export class Lobster {
@@ -58,6 +59,7 @@ export class Lobster {
 		this.#options = {
 			env: options.env ?? process.env,
 			stateDir: options.stateDir,
+			signal: options.signal,
 		};
 	}
 
@@ -83,6 +85,7 @@ export class Lobster {
 			env: this.#options.env,
 			stateDir: this.#options.stateDir,
 			mode: "sdk",
+			signal: this.#options.signal,
 		};
 
 		try {
@@ -288,6 +291,7 @@ export class Lobster {
 			env: this.#options.env,
 			stateDir: this.#options.stateDir,
 			mode: "sdk",
+			signal: this.#options.signal,
 		};
 
 		try {

--- a/src/sdk/primitives/exec.ts
+++ b/src/sdk/primitives/exec.ts
@@ -9,7 +9,7 @@
  *   .pipe(items => items.filter(e => e.unread))
  */
 
-import { spawn } from "node:child_process";
+import { runAbortableProcess } from "../../abortable_process.js";
 import { resolveInlineShellCommand } from "../../shell.js";
 
 /**
@@ -19,40 +19,20 @@ import { resolveInlineShellCommand } from "../../shell.js";
  * @param {Object} options
  * @returns {Promise<{stdout: string, stderr: string}>}
  */
-function runProcess(command, argv, { env, cwd }) {
-	return new Promise<any>((resolve, reject) => {
-		const child = spawn(command, argv, {
-			env,
-			cwd,
-			stdio: ["ignore", "pipe", "pipe"],
-			shell: false,
-		});
-
-		let stdout = "";
-		let stderr = "";
-
-		child.stdout.setEncoding("utf8");
-		child.stderr.setEncoding("utf8");
-
-		child.stdout.on("data", (d) => {
-			stdout += d;
-		});
-		child.stderr.on("data", (d) => {
-			stderr += d;
-		});
-
-		child.on("error", (err) => {
-			reject(new Error(`Failed to execute ${command}: ${err.message}`));
-		});
-
-		child.on("close", (code) => {
-			if (code === 0) {
-				resolve({ stdout, stderr });
-			} else {
-				reject(new Error(`${command} exited with code ${code}: ${stderr.trim() || stdout.trim()}`));
-			}
-		});
+async function runProcess(command, argv, { env, cwd, signal, forceTerminationSignal }) {
+	const { stdout, stderr, code } = await runAbortableProcess({
+		command,
+		argv,
+		env,
+		cwd,
+		signal,
+		forceTerminationSignal,
+		notFoundMessage: `Failed to execute ${command}: spawn ${command} ENOENT`,
 	});
+	if (code === 0) {
+		return { stdout, stderr };
+	}
+	throw new Error(`${command} exited with code ${code}: ${stderr.trim() || stdout.trim()}`);
 }
 
 /**
@@ -136,15 +116,22 @@ export function exec(cmdString, options: any = {}) {
 
 			let stdout;
 
+			const processOptions = {
+				env,
+				cwd,
+				signal: ctx.signal,
+				forceTerminationSignal: ctx.forceTerminationSignal,
+			};
+
 			if (useShell) {
 				// Shell execution
 				const shell = resolveInlineShellCommand({ command: cmdString, env });
-				const result = await runProcess(shell.command, shell.argv, { env, cwd });
+				const result = await runProcess(shell.command, shell.argv, processOptions);
 				stdout = result.stdout;
 			} else {
 				// Direct execution
 				const { command, args } = parseCommand(cmdString);
-				const result = await runProcess(command, args, { env, cwd });
+				const result = await runProcess(command, args, processOptions);
 				stdout = result.stdout;
 			}
 

--- a/src/sdk/runtime.ts
+++ b/src/sdk/runtime.ts
@@ -146,7 +146,7 @@ export async function runPipeline({
 	env,
 	mode = "human",
 	input,
-	signal,
+	signal = undefined,
 	requestInputResume = undefined,
 	requestInputEnabled = true,
 }) {

--- a/src/sdk/runtime.ts
+++ b/src/sdk/runtime.ts
@@ -146,6 +146,7 @@ export async function runPipeline({
 	env,
 	mode = "human",
 	input,
+	signal,
 	requestInputResume = undefined,
 	requestInputEnabled = true,
 }) {
@@ -158,6 +159,7 @@ export async function runPipeline({
 		env,
 		mode,
 		input,
+		signal,
 		requestInputResume,
 		requestInputEnabled,
 	});

--- a/test/sdk_exec.test.ts
+++ b/test/sdk_exec.test.ts
@@ -1,0 +1,138 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Lobster } from "../src/sdk/Lobster.js";
+import { exec, shell } from "../src/sdk/primitives/exec.js";
+
+function emptyInput() {
+	return (async function* () {})();
+}
+
+function quote(value: string) {
+	return JSON.stringify(value);
+}
+
+function longChildCommand() {
+	const script = [
+		'require("node:fs").writeFileSync(process.env.LOBSTER_EXEC_PID_FILE, String(process.pid));',
+		"setTimeout(() => {}, 30000);",
+	].join("");
+	return `${quote(process.execPath)} -e ${quote(script)}`;
+}
+
+async function waitForFile(path: string, timeoutMs = 5000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			await access(path);
+			return;
+		} catch {
+			await new Promise((resolve) => setTimeout(resolve, 10));
+		}
+	}
+	throw new Error(`Timed out waiting for ${path}`);
+}
+
+function processIsRunning(pid: number) {
+	assert.ok(Number.isSafeInteger(pid) && pid > 0, `Invalid child PID: ${pid}`);
+	if (process.platform === "darwin") {
+		const result = spawnSync("/bin/ps", ["-o", "stat=", "-p", String(pid)], { encoding: "utf8" });
+		if (result.stdout?.trim().startsWith("Z")) return false;
+	}
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitUntilStopped(pid: number, timeoutMs = 2000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (!processIsRunning(pid)) return;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error(`Child ${pid} was still running after abort`);
+}
+
+async function runAbortableStage(stage: ReturnType<typeof exec>, signal: AbortSignal, cwd: string) {
+	return stage.run({
+		input: emptyInput(),
+		ctx: {
+			env: { ...process.env, LOBSTER_EXEC_PID_FILE: join(cwd, "pid") },
+			cwd,
+			signal,
+		},
+	});
+}
+
+test("sdk exec abort signal kills a long-running child", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-sdk-exec-abort-"));
+	try {
+		const pidFile = join(dir, "pid");
+		const controller = new AbortController();
+		const pending = runAbortableStage(
+			exec(longChildCommand(), { json: false }),
+			controller.signal,
+			dir,
+		);
+		await waitForFile(pidFile);
+		const pid = Number((await readFile(pidFile, "utf8")).trim());
+		assert.equal(processIsRunning(pid), true);
+		controller.abort(new Error("abort long exec"));
+		await assert.rejects(() => pending, /abort long exec/);
+		await waitUntilStopped(pid);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("sdk shell abort signal kills a long-running child", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-sdk-shell-abort-"));
+	try {
+		const pidFile = join(dir, "pid");
+		const controller = new AbortController();
+		const pending = runAbortableStage(
+			shell(longChildCommand(), { json: false }),
+			controller.signal,
+			dir,
+		);
+		await waitForFile(pidFile);
+		const pid = Number((await readFile(pidFile, "utf8")).trim());
+		assert.equal(processIsRunning(pid), true);
+		controller.abort(new Error("abort long shell"));
+		await assert.rejects(() => pending, /abort long shell/);
+		await waitUntilStopped(pid);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("public Lobster pipe run forwards constructor abort signal", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-public-exec-abort-"));
+	try {
+		const pidFile = join(dir, "pid");
+		const controller = new AbortController();
+		const pending = new Lobster({
+			env: { ...process.env, LOBSTER_EXEC_PID_FILE: pidFile },
+			signal: controller.signal,
+		})
+			.pipe(exec(longChildCommand(), { json: false }))
+			.run();
+		await waitForFile(pidFile);
+		const pid = Number((await readFile(pidFile, "utf8")).trim());
+		assert.equal(processIsRunning(pid), true);
+		controller.abort(new Error("abort public lobster"));
+		const result = await pending;
+		assert.equal(result.ok, false);
+		assert.match(result.error?.message ?? "", /abort public lobster/);
+		await waitUntilStopped(pid);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});

--- a/test/sdk_exec.test.ts
+++ b/test/sdk_exec.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { getEventListeners } from "node:events";
 import { spawnSync } from "node:child_process";
 import { access, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -7,6 +8,7 @@ import { join } from "node:path";
 
 import { Lobster } from "../src/sdk/Lobster.js";
 import { exec, shell } from "../src/sdk/primitives/exec.js";
+import { approve, runPipeline } from "../src/sdk/index.js";
 
 function emptyInput() {
 	return (async function* () {})();
@@ -134,5 +136,96 @@ test("public Lobster pipe run forwards constructor abort signal", async () => {
 		await waitUntilStopped(pid);
 	} finally {
 		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+for (const entry of ["clone", "resume"] as const) {
+	test(`SDK ${entry} preserves the signal and waits for child cleanup`, async () => {
+		const dir = await mkdtemp(join(tmpdir(), `lobster-sdk-${entry}-abort-`));
+		const controller = new AbortController();
+		let pending: Promise<any> | undefined;
+		try {
+			const pidFile = join(dir, "pid");
+			const workflow = new Lobster({
+				env: { ...process.env, LOBSTER_EXEC_PID_FILE: pidFile },
+				signal: controller.signal,
+			});
+			if (entry === "resume") workflow.pipe(approve());
+			workflow.pipe(exec(longChildCommand(), { shell: true, json: false }));
+			if (entry === "resume") {
+				const first = await workflow.run();
+				assert.equal(first.status, "needs_approval");
+				pending = workflow.resume(first.requiresApproval!.resumeToken, { approved: true });
+			} else {
+				pending = workflow.clone().run();
+			}
+			await waitForFile(pidFile);
+			const pid = Number((await readFile(pidFile, "utf8")).trim());
+			controller.abort(new Error(`cancel ${entry}`));
+			const result = await pending;
+			assert.equal(result.ok, false);
+			assert.equal(result.error.message, `cancel ${entry}`);
+			assert.equal(processIsRunning(pid), false, "result must wait for process exit");
+			assert.equal(getEventListeners(controller.signal, "abort").length, 0);
+		} finally {
+			controller.abort();
+			await pending;
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+}
+
+test("pre-aborted SDK exec never starts a child", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-sdk-preabort-"));
+	try {
+		const controller = new AbortController();
+		controller.abort(new Error("already cancelled"));
+		const result = await new Lobster({
+			env: { ...process.env, LOBSTER_EXEC_PID_FILE: join(dir, "pid") },
+			signal: controller.signal,
+		})
+			.pipe(exec(longChildCommand(), { json: false }))
+			.run();
+		assert.equal(result.ok, false);
+		assert.equal(result.error.message, "already cancelled");
+		await assert.rejects(access(join(dir, "pid")), { code: "ENOENT" });
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("SDK exec preserves output and failure handling and releases abort listeners", async () => {
+	const controller = new AbortController();
+	const run = (command: string) =>
+		new Lobster({ signal: controller.signal }).pipe(exec(command)).run();
+	const success = await run(`${quote(process.execPath)} -e ${quote('console.log("[1,2]")')}`);
+	assert.deepEqual(success.output, [1, 2]);
+	const failed = await run(
+		`${quote(process.execPath)} -e ${quote('console.error("failed");process.exit(7)')}`,
+	);
+	assert.equal(failed.ok, false);
+	assert.match(failed.error.message, /exited with code 7: failed/);
+	const missing = await run("lobster-nonexistent-executable-for-test");
+	assert.equal(missing.ok, false);
+	assert.match(missing.error.message, /Failed to execute .* ENOENT/);
+	assert.equal(getEventListeners(controller.signal, "abort").length, 0);
+});
+
+test("exported SDK runPipeline keeps signal optional and forwards supplied signals", async () => {
+	const controller = new AbortController();
+	for (const options of [{}, { signal: controller.signal }]) {
+		const result = await runPipeline({
+			pipeline: [{ name: "signal", args: {} }],
+			registry: {
+				get: () => ({ run: ({ ctx }: any) => ({ output: [ctx.signal === options.signal] }) }),
+			},
+			stdin: { isTTY: false },
+			stdout: { write() {} },
+			stderr: { write() {} },
+			env: process.env,
+			input: [],
+			...options,
+		});
+		assert.deepEqual(result.items, [true]);
 	}
 });


### PR DESCRIPTION
## What Problem This Solves

Cancelling an SDK pipeline left `exec()` and shell children running. The SDK constructor dropped its `signal`, and the process primitive spawned children without forwarding the pipeline signal. The non-abortable wrappers were present in the original JavaScript sources added by [996546b](https://github.com/openclaw/lobster/commit/996546b04829ec9feb741de950080d1c528e8c60).

## Why This Change Was Made

Use the existing `runAbortableProcess` helper and carry the constructor signal through run, clone, and resume. Keep `signal` optional in the exported `runPipeline` TypeScript signature so existing callers still type-check. The process runner retains ownership of termination and cleanup; the SDK returns an error result with the abort reason after cleanup.

This preserves ordinary output and nonzero-exit handling, terminal Ctrl-C for calls without a signal, and existing output-size behavior. Custom stages still need to cooperate with `ctx.signal`. Related: #119 and #145.

## User Impact

A host can cancel `new Lobster({ signal }).pipe(exec(command)).run()`, including shell execution, clones, and resumed pipelines. A pre-aborted command does not spawn. README documentation and regression tests cover these paths.

## Evidence

Validated head: `edc3ddc0cb6888735e6a32a6e29120b9d945cd78` against main `da6698f940226dfa13ed2bff1d25e74af5d494e0`.

- Built TypeScript and passed the focused SDK suites: 14 tests, including clone/resume, pre-abort, ordinary output/errors, listener cleanup, and callers omitting `signal`.
- Real-process proof on macOS arm64, Node v26.8.1: each of SDK run, shell, clone, and resume started a child that issued a stalled request to a local HTTP server. On main, abort left both child and connection alive. With the fix, each child received SIGTERM, exited, and closed the connection in 254–260 ms. Abort listeners were removed and no state was written.
- Real PTY proof without a signal: child stayed in the terminal process group, received Ctrl-C, and exited with status 130. Focused CLI cancellation coverage passed 7 tests, with 2 platform skips, including process-tree cleanup, second SIGINT, and a stalled OpenClaw HTTP call.
- Full-candidate isolated Codex P0–P2 review: no actionable findings after the optional-parameter correction.
- [Node 24 CI](https://github.com/openclaw/lobster/actions/runs/33857607152): passed frozen install, build, typecheck, formatting/lint, and the full test suite. Workflow lint passed. No retry.
- Windows process-tree termination was not exercised. HTTP proof used a local server; no external service or credentials were involved.

Sebastien Tardif (@SebTardif) authored the original fix. Maintainer follow-ups preserve his commit and credit and add compatibility, documentation, and lifecycle coverage. No branch history was rewritten.
