### PR TITLE
chore(deps): update Node.js type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"yaml": "^2.9.0"
 	},
 	"devDependencies": {
-		"@types/node": "^26.3.0",
+		"@types/node": "^26.4.0",
 		"@typescript/native": "npm:typescript@^7.0.2",
 		"oxfmt": "^0.65.0",
 		"oxlint": "^1.80.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         version: 2.9.0
     devDependencies:
       '@types/node':
-        specifier: ^26.3.0
-        version: 26.3.0
+        specifier: ^26.4.0
+        version: 26.4.0
       '@typescript/native':
         specifier: npm:typescript@^7.0.2
         version: typescript@7.0.2
@@ -313,8 +313,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@types/node@26.3.0':
-    resolution: {integrity: sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==}
+  '@types/node@26.4.0':
+    resolution: {integrity: sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -642,7 +642,7 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.80.0':
     optional: true
 
-  '@types/node@26.3.0':
+  '@types/node@26.4.0':
     dependencies:
       undici-types: 8.3.0
 


### PR DESCRIPTION
## What Problem This Solves

Refreshes the development dependency on Node.js type definitions so the repository builds and tests against the current published release.

## Why This Change Was Made

Updates `@types/node` from 26.3.0 to 26.4.0 and regenerates `pnpm-lock.yaml` with the repository's pnpm 11.24.0. `pnpm update` checked the complete dependency graph, and `pnpm outdated --format json` now returns `{}`. Runtime dependencies, the TypeScript aliases, lint/format tooling, the fast-uri override, pnpm, and all GitHub Actions already resolve to their current stable releases. No major upgrades were available or skipped.

## User Impact

No user-visible behavior change. This is a development-only dependency update; no changelog entry is needed.

## Evidence

Local environment: Node v26.8.1 and pnpm 11.24.0. Validation includes frozen installation, build, typecheck, lint/format, the full test suite, and actionlint. Lint reports seven warnings in unchanged code. The production dependency audit reports zero vulnerabilities.

Live proof runs the compiled CLI against the repository's actual package metadata:

```sh
node bin/lobster.js run --mode tool "exec --json --shell 'cat package.json' | pick name,version,engines"
```

```json
{
  "protocolVersion": 1,
  "ok": true,
  "status": "ok",
  "output": [
    {
      "name": "@clawdbot/lobster",
      "version": "2026.6.11",
      "engines": {
        "node": ">=22"
      }
    }
  ],
  "requiresApproval": null,
  "requiresInput": null
}
```

Codex autoreview of the complete dependency diff returned scoped-clean with no accepted/actionable findings at its default P0 scope.

### CI reasoning

The initial NORUNS observation was stale: the current default-branch commit already passed [CI run 33367507061](https://github.com/openclaw/lobster/actions/runs/33367507061), including both Node 24 check and workflow lint. No CI changes are necessary. This PR retains every existing assertion and job. CI runs on pull requests and pushes to main. ClawSweeper Dispatch is operational automation, Crabbox Hydrate is manual environment provisioning, and Lobster npm release is a manual publication workflow; these are separate from build/test CI. No production, release, or provisioning workflows were dispatched.

### Local runtime follow-up

The initial `pnpm test` run on Node 26 with default concurrency reported three `ENOTEMPTY` test-cleanup failures in cancellation replay tests and one missed 500 ms lock-reacquisition deadline. It was stopped after those failures while the filesystem stress test was still running. All four failed tests passed unchanged on Node 24:

```sh
PATH="/opt/homebrew/opt/node@24/bin:$PATH" node --test --test-name-pattern='next-stage input resume cannot replay a send|workflow approval resume cannot replay a send|workflow input resume cannot replay a send|best-effort cleanup cannot remove' dist/test/cancellation.test.js dist/test/state.test.js
```

```text
ℹ tests 4
ℹ pass 4
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
```

The complete suite then passed on Node v24.20.0 with one test file at a time, retaining all assertions and the three existing platform skips:

```sh
PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm exec node --test --test-concurrency=1 dist/test/*.test.js
```

```text
ℹ tests 551
ℹ suites 0
ℹ pass 548
ℹ fail 0
ℹ cancelled 0
ℹ skipped 3
ℹ todo 0
ℹ duration_ms 880058.8725
```

Other completed validation commands:

```sh
pnpm install --frozen-lockfile
pnpm build
pnpm typecheck
pnpm lint
actionlint .github/workflows/*.yml
pnpm audit --prod --json
```

The same live CLI command also passed with Node 24 selected through PATH, with identical JSON output.

### PR checks

[PR CI run 33371376254](https://github.com/openclaw/lobster/actions/runs/33371376254) passed both Node 24 check and Lint workflows with the normal CI concurrency. [CodeQL run 33371373881](https://github.com/openclaw/lobster/actions/runs/33371373881) also passed both Actions and JavaScript/TypeScript analysis. ClawSweeper Dispatch completed successfully as separate operational automation. The PR is intentionally left open for maintainer review and landing.
