### PR TITLE
fix: add opt-in process output limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,39 @@ From this folder:
 
 - `pnpm test` runs `tsc` and then executes tests against `dist/`.
 - `bin/lobster.js` prefers the compiled entrypoint in `dist/` when present.
+## Process output limits
+
+Captured process stdout and stderr remain unlimited by default. Set
+`LOBSTER_MAX_OUTPUT_BYTES` to a positive integer to opt into a byte limit **per
+stream, per process**. Unset or empty means unlimited; zero, negative, fractional,
+and non-numeric values are rejected before a process starts. This applies to
+CLI `exec`, workflow shell steps, SDK `exec`/shell calls, GitHub recipes, and Gog
+commands. The existing `openclaw.agent` 10 MiB limit remains in place; an opted-in
+limit can lower it.
+
+```bash
+LOBSTER_MAX_OUTPUT_BYTES=1048576 lobster run --mode tool 'exec my-command'
+```
+
+Use workflow or step `env` to scope the limit:
+
+```yaml
+steps:
+  - id: bounded
+    env:
+      LOBSTER_MAX_OUTPUT_BYTES: "1048576"
+    run: my-command
+```
+
+SDK callers set the same variable in `new Lobster({ env: { ...process.env,
+LOBSTER_MAX_OUTPUT_BYTES: "1048576" } })`. Values exactly at the limit succeed;
+overflow terminates the process tree and returns an error without partial
+output. POSIX capped calls own a process group so background producers cannot
+keep pipes open after overflow. Calls without an AbortSignal relay terminal
+interrupts to that group and retain the host's existing signal handlers or
+conventional interrupt exit status.
+
+
 ## Commands
 
 - `exec`: run OS commands
@@ -405,35 +438,3 @@ steps:
     command: |
       jq -n --arg text "$TEXT" '{"result": $text}'
 ```
-
-## Process output limits
-
-Captured process stdout and stderr remain unlimited by default. Set
-`LOBSTER_MAX_OUTPUT_BYTES` to a positive integer to opt into a byte limit **per
-stream, per process**. Unset or empty means unlimited; zero, negative, fractional,
-and non-numeric values are rejected before a process starts. This applies to
-CLI `exec`, workflow shell steps, SDK `exec`/shell calls, GitHub recipes, and Gog
-commands. The existing `openclaw.agent` 10 MiB limit remains in place; an opted-in
-limit can lower it.
-
-```bash
-LOBSTER_MAX_OUTPUT_BYTES=1048576 lobster run --mode tool 'exec my-command'
-```
-
-Use workflow or step `env` to scope the limit:
-
-```yaml
-steps:
-  - id: bounded
-    env:
-      LOBSTER_MAX_OUTPUT_BYTES: "1048576"
-    run: my-command
-```
-
-SDK callers set the same variable in `new Lobster({ env: { ...process.env,
-LOBSTER_MAX_OUTPUT_BYTES: "1048576" } })`. Values exactly at the limit succeed;
-overflow terminates the process tree and returns an error without partial
-output. POSIX capped calls own a process group so background producers cannot
-keep pipes open after overflow. Calls without an AbortSignal relay terminal
-interrupts to that group and retain the host's existing signal handlers or
-conventional interrupt exit status.

--- a/README.md
+++ b/README.md
@@ -405,3 +405,35 @@ steps:
     command: |
       jq -n --arg text "$TEXT" '{"result": $text}'
 ```
+
+## Process output limits
+
+Captured process stdout and stderr remain unlimited by default. Set
+`LOBSTER_MAX_OUTPUT_BYTES` to a positive integer to opt into a byte limit **per
+stream, per process**. Unset or empty means unlimited; zero, negative, fractional,
+and non-numeric values are rejected before a process starts. This applies to
+CLI `exec`, workflow shell steps, SDK `exec`/shell calls, GitHub recipes, and Gog
+commands. The existing `openclaw.agent` 10 MiB limit remains in place; an opted-in
+limit can lower it.
+
+```bash
+LOBSTER_MAX_OUTPUT_BYTES=1048576 lobster run --mode tool 'exec my-command'
+```
+
+Use workflow or step `env` to scope the limit:
+
+```yaml
+steps:
+  - id: bounded
+    env:
+      LOBSTER_MAX_OUTPUT_BYTES: "1048576"
+    run: my-command
+```
+
+SDK callers set the same variable in `new Lobster({ env: { ...process.env,
+LOBSTER_MAX_OUTPUT_BYTES: "1048576" } })`. Values exactly at the limit succeed;
+overflow terminates the process tree and returns an error without partial
+output. POSIX capped calls own a process group so background producers cannot
+keep pipes open after overflow. Calls without an AbortSignal relay terminal
+interrupts to that group and retain the host's existing signal handlers or
+conventional interrupt exit status.

--- a/src/abortable_process.ts
+++ b/src/abortable_process.ts
@@ -27,7 +27,8 @@ function registerInterruptTarget(target: InterruptTarget): () => void {
 				});
 			};
 			interruptHandlers.set(signal, handler);
-			process.on(signal, handler);
+			// Observe existing once-handlers before EventEmitter removes them.
+			process.prependListener(signal, handler);
 		}
 	}
 	interruptTargets.add(target);

--- a/src/abortable_process.ts
+++ b/src/abortable_process.ts
@@ -1,8 +1,55 @@
 import { spawn, type ChildProcess, type SpawnOptionsWithoutStdio } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
 import { resolveInlineShellCommand } from "./shell.js";
 
 const ABORT_FORCE_KILL_AFTER_MS = 250;
 const forceTerminationCallbacks = new WeakMap<AbortSignal, Set<() => void>>();
+
+// Capped direct SDK calls have no host AbortSignal, but their isolated children
+// must still receive terminal interrupts and be killed if the host exits.
+const interruptSignals = { SIGINT: 130, SIGTERM: 143, SIGHUP: 129, SIGQUIT: 131 } as const;
+type InterruptSignal = keyof typeof interruptSignals;
+type InterruptTarget = { stop: (signal: InterruptSignal) => Promise<void>; kill: () => void };
+const interruptTargets = new Set<InterruptTarget>();
+const interruptHandlers = new Map<InterruptSignal, () => void>();
+const killOnExit = () => {
+	for (const target of interruptTargets) target.kill();
+};
+
+function registerInterruptTarget(target: InterruptTarget): () => void {
+	if (interruptTargets.size === 0) {
+		process.on("exit", killOnExit);
+		for (const signal of Object.keys(interruptSignals) as InterruptSignal[]) {
+			const handler = () => {
+				const defaultExit = process.listenerCount(signal) === 1;
+				void Promise.allSettled([...interruptTargets].map((item) => item.stop(signal))).then(() => {
+					if (defaultExit) process.exit(interruptSignals[signal]);
+				});
+			};
+			interruptHandlers.set(signal, handler);
+			process.on(signal, handler);
+		}
+	}
+	interruptTargets.add(target);
+	return () => {
+		interruptTargets.delete(target);
+		if (interruptTargets.size === 0) {
+			process.removeListener("exit", killOnExit);
+			for (const [signal, handler] of interruptHandlers) process.removeListener(signal, handler);
+			interruptHandlers.clear();
+		}
+	};
+}
+
+function outputLimitFromEnv(env: NodeJS.ProcessEnv): number | undefined {
+	const raw = env.LOBSTER_MAX_OUTPUT_BYTES?.trim();
+	if (!raw) return undefined;
+	const value = Number(raw);
+	if (!/^\d+$/.test(raw) || !Number.isSafeInteger(value) || value <= 0) {
+		throw new Error("LOBSTER_MAX_OUTPUT_BYTES must be a positive safe integer (bytes)");
+	}
+	return value;
+}
 
 type ProcessResult = {
 	stdout: string;
@@ -72,18 +119,25 @@ export function runAbortableProcess(options: RunAbortableProcessOptions): Promis
 		signal,
 		forceTerminationSignal,
 		killSignal,
-		maxOutputBytes,
+		maxOutputBytes: requestedMaxOutputBytes,
 		outputLimitMessage,
 		notFoundMessage,
 	} = options;
 	return new Promise((resolve, reject) => {
 		if (
-			maxOutputBytes !== undefined &&
-			(!Number.isSafeInteger(maxOutputBytes) || maxOutputBytes < 0)
+			requestedMaxOutputBytes !== undefined &&
+			(!Number.isSafeInteger(requestedMaxOutputBytes) || requestedMaxOutputBytes < 0)
 		) {
 			reject(new Error("maxOutputBytes must be a non-negative safe integer"));
 			return;
 		}
+		const envLimit = outputLimitFromEnv(env);
+		const maxOutputBytes =
+			envLimit === undefined
+				? requestedMaxOutputBytes
+				: requestedMaxOutputBytes === undefined
+					? envLimit
+					: Math.min(envLimit, requestedMaxOutputBytes);
 		try {
 			signal?.throwIfAborted();
 		} catch (err) {
@@ -95,10 +149,9 @@ export function runAbortableProcess(options: RunAbortableProcessOptions): Promis
 			cwd,
 			shell: false,
 			stdio: "pipe",
-			// Create a dedicated POSIX process group only when this runner owns a
-			// cancellation signal for it. Direct APIs without one must retain the
-			// caller's terminal process group so Ctrl-C still reaches their child.
-			detached: process.platform !== "win32" && signal !== undefined,
+			// A finite cap also owns termination, including background descendants.
+			detached:
+				process.platform !== "win32" && (signal !== undefined || maxOutputBytes !== undefined),
 		};
 		// Keep direct argv and shell command dataflow at distinct spawn sites.
 		// Merging them makes shell interpretation leak into direct executable callers.
@@ -110,6 +163,8 @@ export function runAbortableProcess(options: RunAbortableProcessOptions): Promis
 					})()
 				: spawn(options.command, options.argv, spawnOptions);
 
+		const stdoutDecoder = new StringDecoder("utf8");
+		const stderrDecoder = new StringDecoder("utf8");
 		let stdout = "";
 		let stderr = "";
 		let stdoutBytes = 0;
@@ -122,7 +177,14 @@ export function runAbortableProcess(options: RunAbortableProcessOptions): Promis
 		let settled = false;
 		const forceTerminationRegistrations: Set<() => void>[] = [];
 		let forceTerminate: (() => void) | undefined;
+		let unregisterInterruptTarget: (() => void) | undefined;
+		let resolveStopped: () => void;
+		const stopped = new Promise<void>((resolve) => {
+			resolveStopped = resolve;
+		});
 		const cleanup = () => {
+			unregisterInterruptTarget?.();
+			resolveStopped();
 			signal?.removeEventListener("abort", onAbort);
 			if (forceKillTimer) clearTimeout(forceKillTimer);
 			if (forceTerminate) {
@@ -149,11 +211,13 @@ export function runAbortableProcess(options: RunAbortableProcessOptions): Promis
 				failTerminationWhenTreeIsStopped();
 			});
 		};
-		const startTermination = (error: Error) => {
+		const startTermination = (error: Error, receivedSignal?: NodeJS.Signals) => {
 			if (settled || terminationError) return;
 			terminationError = error;
 			const initialKillSignal =
-				(typeof killSignal === "function" ? killSignal() : killSignal) ?? "SIGTERM";
+				receivedSignal ??
+				(typeof killSignal === "function" ? killSignal() : killSignal) ??
+				"SIGTERM";
 			if (initialKillSignal === "SIGKILL") {
 				forceKill();
 				return;
@@ -179,28 +243,30 @@ export function runAbortableProcess(options: RunAbortableProcessOptions): Promis
 			if (!signal) return;
 			startTermination(abortError(signal));
 		};
-		const appendOutput = (stream: "stdout" | "stderr", data: string) => {
-			const bytes = Buffer.byteLength(data);
+		const appendOutput = (stream: "stdout" | "stderr", data: Buffer) => {
+			if (terminationError || settled) return;
+			const bytes = data.byteLength;
 			const total = stream === "stdout" ? stdoutBytes + bytes : stderrBytes + bytes;
 			if (maxOutputBytes !== undefined && total > maxOutputBytes) {
 				startTermination(
-					new Error(outputLimitMessage ?? `Process output exceeded ${maxOutputBytes} bytes`),
+					new Error(
+						(maxOutputBytes === requestedMaxOutputBytes ? outputLimitMessage : undefined) ??
+							`Process output exceeded ${maxOutputBytes} bytes`,
+					),
 				);
 				return;
 			}
 			if (stream === "stdout") {
 				stdoutBytes = total;
-				stdout += data;
+				stdout += stdoutDecoder.write(data);
 			} else {
 				stderrBytes = total;
-				stderr += data;
+				stderr += stderrDecoder.write(data);
 			}
 		};
 
-		child.stdout?.setEncoding("utf8");
-		child.stderr?.setEncoding("utf8");
-		child.stdout?.on("data", (data: string) => appendOutput("stdout", data));
-		child.stderr?.on("data", (data: string) => appendOutput("stderr", data));
+		child.stdout?.on("data", (data: Buffer) => appendOutput("stdout", data));
+		child.stderr?.on("data", (data: Buffer) => appendOutput("stderr", data));
 		child.stdin?.on("error", () => {});
 		if (typeof stdin === "string") child.stdin?.write(stdin);
 		child.stdin?.end();
@@ -226,7 +292,7 @@ export function runAbortableProcess(options: RunAbortableProcessOptions): Promis
 			}
 			settled = true;
 			cleanup();
-			resolve({ stdout, stderr, code });
+			resolve({ stdout: stdout + stdoutDecoder.end(), stderr: stderr + stderrDecoder.end(), code });
 		});
 
 		for (const registrationSignal of new Set(
@@ -241,6 +307,25 @@ export function runAbortableProcess(options: RunAbortableProcessOptions): Promis
 			}
 			listeners.add(forceTerminate);
 			forceTerminationRegistrations.push(listeners);
+		}
+
+		if (spawnOptions.detached && signal === undefined) {
+			unregisterInterruptTarget = registerInterruptTarget({
+				stop(receivedSignal) {
+					if (terminationError) forceKill();
+					else startTermination(new Error(`Received ${receivedSignal}`), receivedSignal);
+					return stopped;
+				},
+				kill() {
+					if (child.pid) {
+						try {
+							process.kill(-child.pid, "SIGKILL");
+						} catch {
+							/* Already exited. */
+						}
+					}
+				},
+			});
 		}
 
 		if (signal) {

--- a/test/gog_gmail_send.test.ts
+++ b/test/gog_gmail_send.test.ts
@@ -1,7 +1,8 @@
 import test from "node:test";
+import { waitForPid } from "./helpers/wait_for_pid.js";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { access, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -26,15 +27,6 @@ async function fileExists(path: string) {
 	}
 }
 
-async function waitForFile(path: string, timeoutMs = 5000) {
-	const deadline = Date.now() + timeoutMs;
-	while (Date.now() < deadline) {
-		if (await fileExists(path)) return;
-		await new Promise((resolve) => setTimeout(resolve, 10));
-	}
-	throw new Error(`Timed out waiting for ${path}`);
-}
-
 function processIsRunning(pid: number) {
 	try {
 		const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
@@ -53,6 +45,8 @@ function processIsRunning(pid: number) {
 
 test("aborting gog.gmail.send terminates the sleeper gog child", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-gmail-send-abort-"));
+	const controller = new AbortController();
+	let run: Promise<any> | undefined;
 	try {
 		const repoRoot = join(__dirname, "..", "..");
 		const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
@@ -61,9 +55,8 @@ test("aborting gog.gmail.send terminates the sleeper gog child", async () => {
 		const sendCompleted = join(dir, "send-completed");
 		const descendantStarted = join(dir, "descendant-started");
 		const descendantCompleted = join(dir, "descendant-completed");
-		const controller = new AbortController();
 
-		const run = gogGmailSendCommand.run({
+		run = gogGmailSendCommand.run({
 			input: streamOf([{ to: "user@example.com", subject: "Hello", body: "World" }]),
 			args: {},
 			ctx: {
@@ -82,10 +75,8 @@ test("aborting gog.gmail.send terminates the sleeper gog child", async () => {
 			},
 		});
 
-		await waitForFile(sendStarted);
-		await waitForFile(descendantStarted);
-		const childPid = Number(await readFile(sendStarted, "utf8"));
-		const descendantPid = Number(await readFile(descendantStarted, "utf8"));
+		const childPid = await waitForPid(sendStarted);
+		const descendantPid = await waitForPid(descendantStarted);
 		assert.ok(Number.isInteger(childPid) && childPid > 0);
 		assert.ok(Number.isInteger(descendantPid) && descendantPid > 0);
 		controller.abort(new Error("abort in-flight gog.gmail.send"));
@@ -113,6 +104,8 @@ test("aborting gog.gmail.send terminates the sleeper gog child", async () => {
 			"a send descendant must not finish after abort",
 		);
 	} finally {
+		controller.abort();
+		await run?.catch(() => {});
 		await rm(dir, { recursive: true, force: true });
 	}
 });

--- a/test/process_output_limit.test.ts
+++ b/test/process_output_limit.test.ts
@@ -114,7 +114,7 @@ function isAlive(pid: number) {
 	return stat !== "" && !stat.startsWith("Z");
 }
 
-for (const mode of ["overflow", "interrupt", "host-handler", "host-exit"]) {
+for (const mode of ["overflow", "interrupt", "host-handler", "once-handler", "host-exit"]) {
 	test(
 		`capped no-signal SDK shell cleans its background producer on ${mode}`,
 		{ skip: process.platform === "win32", timeout: 15_000 },
@@ -138,7 +138,7 @@ setInterval(()=>{${mode === "overflow" ? "process.stdout.write('x'.repeat(2048))
 				await writeFile(
 					runner,
 					`import {Lobster,exec} from ${quote(new URL("../src/sdk/index.js", import.meta.url).href)};
-${mode === "host-handler" ? "process.on('SIGINT',()=>console.log('host handled SIGINT'));" : ""}
+${mode === "host-handler" || mode === "once-handler" ? `process.${mode === "once-handler" ? "once" : "on"}('SIGINT',()=>console.log('host handled SIGINT'));` : ""}
 ${mode === "host-exit" ? "process.on('SIGUSR2',()=>process.exit(0));" : ""}
 const result=await new Lobster({env:{...process.env,LOBSTER_MAX_OUTPUT_BYTES:'1024'}})
 .pipe(exec(${quote(`${quote(process.execPath)} ${quote(producer)} & wait`)},{shell:true,json:false})).run();
@@ -154,7 +154,8 @@ console.log(JSON.stringify(result));`,
 				wrapper.stderr!.on("data", (x) => (stderr += x));
 				const closed = new Promise<number | null>((resolve) => wrapper!.once("close", resolve));
 				pid = await waitForPid(marker);
-				if (mode === "interrupt" || mode === "host-handler") wrapper.kill("SIGINT");
+				if (mode === "interrupt" || mode === "host-handler" || mode === "once-handler")
+					wrapper.kill("SIGINT");
 				if (mode === "host-exit") wrapper.kill("SIGUSR2");
 				let timer: ReturnType<typeof setTimeout>;
 				const code = await Promise.race([
@@ -166,8 +167,9 @@ console.log(JSON.stringify(result));`,
 				assert.equal(code, mode === "interrupt" ? 130 : 0, stderr);
 				assert.equal(isAlive(pid), false, "producer must not survive its owner");
 				if (mode === "overflow") assert.match(stdout, /Process output exceeded 1024 bytes/);
-				if (mode === "host-handler") assert.match(stdout, /host handled SIGINT/);
-				if (mode === "interrupt" || mode === "host-handler")
+				if (mode === "host-handler" || mode === "once-handler")
+					assert.match(stdout, /host handled SIGINT/);
+				if (mode === "interrupt" || mode === "host-handler" || mode === "once-handler")
 					assert.equal(await readFile(received, "utf8"), "SIGINT");
 			} finally {
 				if (pid) {

--- a/test/process_output_limit.test.ts
+++ b/test/process_output_limit.test.ts
@@ -1,0 +1,187 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFile, spawn, spawnSync } from "node:child_process";
+import { mkdtemp, writeFile, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { Lobster, exec } from "../src/sdk/index.js";
+import { runAbortableProcess } from "../src/abortable_process.js";
+import { waitForPid } from "./helpers/wait_for_pid.js";
+
+const run = promisify(execFile);
+const large = 10 * 1024 * 1024 + 1;
+const cli = path.resolve("bin/lobster.js");
+const quote = (s: string) => JSON.stringify(s);
+
+for (const stream of ["stdout", "stderr"]) {
+	test(`SDK ${stream} is unlimited by default and honors the opt-in byte limit`, async () => {
+		const dir = await mkdtemp(path.join(tmpdir(), "lobster-output-"));
+		try {
+			const file = path.join(dir, "emit.cjs");
+			await writeFile(file, `process.${stream}.write('x'.repeat(${large}));`);
+			for (const limit of ["", "1024"]) {
+				const result = await new Lobster({
+					env: { ...process.env, LOBSTER_MAX_OUTPUT_BYTES: limit },
+				})
+					.pipe(exec(`${quote(process.execPath)} ${quote(file)}`, { json: false }))
+					.run();
+				assert.equal(result.ok, limit === "");
+				if (limit) assert.match(result.error.message, /Process output exceeded 1024 bytes/);
+				else assert.equal(result.output[0].length, stream === "stdout" ? large : 0);
+			}
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+}
+
+test("process caps count actual bytes and accept the exact boundary", async () => {
+	for (const bytes of [Buffer.from("😀"), Buffer.from([0xff, 0xff, 0xff, 0xff])]) {
+		const result = await runAbortableProcess({
+			command: process.execPath,
+			argv: ["-e", `process.stdout.write(Buffer.from('${bytes.toString("hex")}', 'hex'))`],
+			env: { ...process.env, LOBSTER_MAX_OUTPUT_BYTES: "4" },
+			notFoundMessage: "node missing",
+		});
+		assert.equal(result.stdout, bytes.toString("utf8"));
+	}
+});
+
+test("invalid process limits fail before spawning", async () => {
+	const dir = await mkdtemp(path.join(tmpdir(), "lobster-invalid-limit-"));
+	try {
+		const marker = path.join(dir, "started");
+		for (const value of ["0", "-1", "1.5", "Infinity", "true", "9007199254740992"]) {
+			await assert.rejects(
+				runAbortableProcess({
+					command: process.execPath,
+					argv: ["-e", `require('node:fs').writeFileSync(${quote(marker)}, 'started')`],
+					env: { ...process.env, LOBSTER_MAX_OUTPUT_BYTES: value },
+					notFoundMessage: "node missing",
+				}),
+				/LOBSTER_MAX_OUTPUT_BYTES must be a positive safe integer/,
+			);
+		}
+		await assert.rejects(readFile(marker), { code: "ENOENT" });
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("built CLI exec and workflow env preserve unlimited output and enable finite limits", async () => {
+	const dir = await mkdtemp(path.join(tmpdir(), "lobster-cli-limit-"));
+	try {
+		const file = path.join(dir, "emit.cjs");
+		await writeFile(file, `process.stdout.write('x'.repeat(${large}));`);
+		const command = `${quote(process.execPath)} ${quote(file)}`;
+		for (const workflow of [false, true]) {
+			for (const limit of ["", "1024"]) {
+				const filePath = path.join(dir, "workflow.json");
+				await writeFile(
+					filePath,
+					JSON.stringify({
+						steps: [{ id: "emit", run: command, env: { LOBSTER_MAX_OUTPUT_BYTES: limit } }],
+					}),
+				);
+				const args = workflow ? ["--file", filePath] : [`exec ${command}`];
+				const result = await run(process.execPath, [cli, "run", "--mode", "tool", ...args], {
+					env: {
+						...process.env,
+						LOBSTER_MAX_OUTPUT_BYTES: workflow ? "" : limit,
+						LOBSTER_STATE_DIR: path.join(dir, "state"),
+					},
+					maxBuffer: 20 * 1024 * 1024,
+				}).then(
+					(r) => ({ code: 0, stdout: r.stdout }),
+					(e) => ({ code: e.code, stdout: e.stdout }),
+				);
+				const envelope = JSON.parse(result.stdout);
+				assert.equal(envelope.ok, limit === "");
+				if (limit) assert.match(envelope.error.message, /Process output exceeded 1024 bytes/);
+				else assert.equal(envelope.output[0].length, large);
+			}
+		}
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+function isAlive(pid: number) {
+	const stat = spawnSync("ps", ["-o", "stat=", "-p", String(pid)], {
+		encoding: "utf8",
+	}).stdout.trim();
+	return stat !== "" && !stat.startsWith("Z");
+}
+
+for (const mode of ["overflow", "interrupt", "host-handler", "host-exit"]) {
+	test(
+		`capped no-signal SDK shell cleans its background producer on ${mode}`,
+		{ skip: process.platform === "win32", timeout: 15_000 },
+		async () => {
+			const dir = await mkdtemp(path.join(tmpdir(), "lobster-output-tree-"));
+			let wrapper: ReturnType<typeof spawn> | undefined;
+			let pid: number | undefined;
+			try {
+				const producer = path.join(dir, "producer.cjs"),
+					runner = path.join(dir, "runner.mjs");
+				const marker = path.join(dir, "pid"),
+					received = path.join(dir, "signal");
+				await writeFile(
+					producer,
+					`const fs=require('node:fs');
+process.on('SIGTERM',()=>{});
+process.on('SIGINT',()=>fs.writeFileSync(${quote(received)}, 'SIGINT'));
+fs.writeFileSync(${quote(marker)},String(process.pid));
+setInterval(()=>{${mode === "overflow" ? "process.stdout.write('x'.repeat(2048));" : ""}},30);`,
+				);
+				await writeFile(
+					runner,
+					`import {Lobster,exec} from ${quote(new URL("../src/sdk/index.js", import.meta.url).href)};
+${mode === "host-handler" ? "process.on('SIGINT',()=>console.log('host handled SIGINT'));" : ""}
+${mode === "host-exit" ? "process.on('SIGUSR2',()=>process.exit(0));" : ""}
+const result=await new Lobster({env:{...process.env,LOBSTER_MAX_OUTPUT_BYTES:'1024'}})
+.pipe(exec(${quote(`${quote(process.execPath)} ${quote(producer)} & wait`)},{shell:true,json:false})).run();
+console.log(JSON.stringify(result));`,
+				);
+				wrapper = spawn(process.execPath, [runner], {
+					detached: true,
+					stdio: ["ignore", "pipe", "pipe"],
+				});
+				let stdout = "",
+					stderr = "";
+				wrapper.stdout!.on("data", (x) => (stdout += x));
+				wrapper.stderr!.on("data", (x) => (stderr += x));
+				const closed = new Promise<number | null>((resolve) => wrapper!.once("close", resolve));
+				pid = await waitForPid(marker);
+				if (mode === "interrupt" || mode === "host-handler") wrapper.kill("SIGINT");
+				if (mode === "host-exit") wrapper.kill("SIGUSR2");
+				let timer: ReturnType<typeof setTimeout>;
+				const code = await Promise.race([
+					closed,
+					new Promise<never>((_, reject) => {
+						timer = setTimeout(() => reject(new Error(`wrapper hung: ${stderr}`)), 5000);
+					}),
+				]).finally(() => clearTimeout(timer));
+				assert.equal(code, mode === "interrupt" ? 130 : 0, stderr);
+				assert.equal(isAlive(pid), false, "producer must not survive its owner");
+				if (mode === "overflow") assert.match(stdout, /Process output exceeded 1024 bytes/);
+				if (mode === "host-handler") assert.match(stdout, /host handled SIGINT/);
+				if (mode === "interrupt" || mode === "host-handler")
+					assert.equal(await readFile(received, "utf8"), "SIGINT");
+			} finally {
+				if (pid) {
+					try {
+						process.kill(pid, "SIGKILL");
+					} catch {}
+				}
+				if (wrapper?.pid) {
+					try {
+						process.kill(-wrapper.pid, "SIGKILL");
+					} catch {}
+				}
+				await rm(dir, { recursive: true, force: true });
+			}
+		},
+	);
+}


### PR DESCRIPTION
Add opt-in process output limits with `LOBSTER_MAX_OUTPUT_BYTES`, keeping stdout and stderr unlimited by default. The same positive-integer setting works in CLI environments, workflow/step `env`, and SDK contexts. It limits each stream independently; unset or empty retains existing behavior. Existing command-specific bounds, including openclaw.agent's 10 MiB limit, remain effective.

All existing process callers share the limit at the process owner. Capture counts actual bytes and preserves UTF-8 decoding. A capped POSIX call owns its process group, so overflow kills background producers as well as the immediate shell. Capped SDK calls without an AbortSignal forward terminal interrupts, preserve existing persistent and one-shot host handlers, and clean up children if the host exits.

Live proof on macOS / Node 24.20.0: built CLI and SDK runs accept 10,485,761 bytes by default, and reject the same output with an explicit 1,024-byte limit. A real PTY Ctrl-C exits the wrapper with 130, delivers SIGINT to the producer, and leaves no producer running. A one-shot host SIGINT handler is allowed to continue the host instead of forcing exit.

Ten focused integration cases cover unlimited stdout/stderr, finite limits, exact byte boundaries (including malformed UTF-8), invalid configuration before spawn, workflow environment propagation, overflow, terminal interruption, host handlers, and host exit.

The credited changelog entry is intentionally in #151 alongside its HTTP-limit entry, as requested. The README changes use a separate section location so #151 can follow without a documentation conflict. Thanks @SebTardif.

Full local suite on the final code: 594 passed, 3 platform skips, zero failures. The final full run also caught and repaired the existing Gog cancellation test's empty-PID readiness race using the helper from #154.
