### PR TITLE
test: wait for complete child PID readiness markers

### DIFF
--- a/test/github_pr_view.test.ts
+++ b/test/github_pr_view.test.ts
@@ -1,8 +1,9 @@
 import test from "node:test";
+import { waitForPid } from "./helpers/wait_for_pid.js";
 import assert from "node:assert/strict";
 import { getEventListeners } from "node:events";
 import { spawnSync } from "node:child_process";
-import { access, chmod, copyFile, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { access, chmod, copyFile, mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -15,19 +16,6 @@ const __dirname = dirname(__filename);
 
 function emptyInput() {
 	return (async function* () {})();
-}
-
-async function waitForFile(path: string, timeoutMs = 5000) {
-	const deadline = Date.now() + timeoutMs;
-	while (Date.now() < deadline) {
-		try {
-			await access(path);
-			return;
-		} catch {
-			await new Promise((resolve) => setTimeout(resolve, 10));
-		}
-	}
-	throw new Error(`Timed out waiting for ${path}`);
 }
 
 async function fileExists(path: string) {
@@ -94,8 +82,7 @@ test(
 				},
 			});
 
-			await waitForFile(started);
-			const pid = Number((await readFile(started, "utf8")).trim());
+			const pid = await waitForPid(started);
 			assert.equal(processIsRunning(pid), true);
 			controller.abort(new Error("abort stuck gh pr view"));
 			await assert.rejects(() => pending, /abort stuck gh pr view/);
@@ -139,8 +126,7 @@ test(
 				.pipe(ghPrView({ repo: "openclaw/lobster", pr: 1 }))
 				.run();
 
-			await waitForFile(started);
-			const pid = Number((await readFile(started, "utf8")).trim());
+			const pid = await waitForPid(started);
 			assert.equal(processIsRunning(pid), true);
 			controller.abort(new Error("abort public lobster gh pr view"));
 			const result = await pending;
@@ -184,8 +170,7 @@ for (const recipe of [prMonitor, prMonitorNotify]) {
 					MOCK_GH_COMPLETION_DELAY_MS: "5000",
 				});
 				pending = recipe({ repo: "example/repo", pr: 1, signal: controller.signal }).run();
-				await waitForFile(started);
-				const pid = Number((await readFile(started, "utf8")).trim());
+				const pid = await waitForPid(started);
 				controller.abort(new Error(`cancel ${recipe.name}`));
 				const result = await pending;
 				assert.equal(result.ok, false);

--- a/test/helpers/wait_for_pid.ts
+++ b/test/helpers/wait_for_pid.ts
@@ -1,0 +1,16 @@
+import { readFile } from "node:fs/promises";
+
+export async function waitForPid(path: string, timeoutMs = 5000): Promise<number> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			// File creation becomes visible before the fixture writes its PID.
+			const pid = Number((await readFile(path, "utf8")).trim());
+			if (Number.isSafeInteger(pid) && pid > 0) return pid;
+		} catch (error: any) {
+			if (error.code !== "ENOENT") throw error;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error(`Timed out waiting for PID in ${path}`);
+}

--- a/test/sdk_exec.test.ts
+++ b/test/sdk_exec.test.ts
@@ -1,8 +1,9 @@
 import test from "node:test";
+import { waitForPid } from "./helpers/wait_for_pid.js";
 import assert from "node:assert/strict";
 import { getEventListeners } from "node:events";
 import { spawnSync } from "node:child_process";
-import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { access, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -24,19 +25,6 @@ function longChildCommand() {
 		"setTimeout(() => {}, 30000);",
 	].join("");
 	return `${quote(process.execPath)} -e ${quote(script)}`;
-}
-
-async function waitForFile(path: string, timeoutMs = 5000) {
-	const deadline = Date.now() + timeoutMs;
-	while (Date.now() < deadline) {
-		try {
-			await access(path);
-			return;
-		} catch {
-			await new Promise((resolve) => setTimeout(resolve, 10));
-		}
-	}
-	throw new Error(`Timed out waiting for ${path}`);
 }
 
 function processIsRunning(pid: number) {
@@ -83,8 +71,7 @@ test("sdk exec abort signal kills a long-running child", async () => {
 			controller.signal,
 			dir,
 		);
-		await waitForFile(pidFile);
-		const pid = Number((await readFile(pidFile, "utf8")).trim());
+		const pid = await waitForPid(pidFile);
 		assert.equal(processIsRunning(pid), true);
 		controller.abort(new Error("abort long exec"));
 		await assert.rejects(() => pending, /abort long exec/);
@@ -104,8 +91,7 @@ test("sdk shell abort signal kills a long-running child", async () => {
 			controller.signal,
 			dir,
 		);
-		await waitForFile(pidFile);
-		const pid = Number((await readFile(pidFile, "utf8")).trim());
+		const pid = await waitForPid(pidFile);
 		assert.equal(processIsRunning(pid), true);
 		controller.abort(new Error("abort long shell"));
 		await assert.rejects(() => pending, /abort long shell/);
@@ -126,8 +112,7 @@ test("public Lobster pipe run forwards constructor abort signal", async () => {
 		})
 			.pipe(exec(longChildCommand(), { json: false }))
 			.run();
-		await waitForFile(pidFile);
-		const pid = Number((await readFile(pidFile, "utf8")).trim());
+		const pid = await waitForPid(pidFile);
 		assert.equal(processIsRunning(pid), true);
 		controller.abort(new Error("abort public lobster"));
 		const result = await pending;
@@ -159,8 +144,7 @@ for (const entry of ["clone", "resume"] as const) {
 			} else {
 				pending = workflow.clone().run();
 			}
-			await waitForFile(pidFile);
-			const pid = Number((await readFile(pidFile, "utf8")).trim());
+			const pid = await waitForPid(pidFile);
 			controller.abort(new Error(`cancel ${entry}`));
 			const result = await pending;
 			assert.equal(result.ok, false);


### PR DESCRIPTION
Cancellation tests sometimes read an empty PID marker immediately after the child creates it, treating the empty string as PID 0 and failing before checking cancellation. This occurred in both the GitHub recipe and SDK resume tests during local full-suite runs.

Wait for a positive, safe-integer PID and share that readiness check between the two suites. The cancellation assertions and production code stay unchanged.

Validation: all 563 tests complete (560 pass, 3 platform skips); lint passes. A delayed-write integration check proves an empty marker does not release the waiter and the completed PID does. The existing SDK/recipe tests run real child processes. Independent local and branch autoreview are clean through P2.
