### PR TITLE
ci: retry npm latest dist-tag read-back after promotion

### DIFF
--- a/.github/workflows/lobster-npm-release.yml
+++ b/.github/workflows/lobster-npm-release.yml
@@ -561,9 +561,23 @@ jobs:
           printf '//registry.npmjs.org/:_authToken=%s\n' "$NODE_AUTH_TOKEN" > "$HOME/.npmrc"
           npm whoami >/dev/null
           npm dist-tag add "${PACKAGE_NAME}@${RELEASE_VERSION}" latest
-          promoted_latest="$(npm view "${PACKAGE_NAME}" dist-tags.latest)"
-          if [[ "${promoted_latest}" != "${RELEASE_VERSION}" ]]; then
-            echo "npm latest points at ${promoted_latest}, expected ${RELEASE_VERSION} after promotion." >&2
-            exit 1
-          fi
+
+          # The registry can lag behind a successful dist-tag write, so poll the
+          # read-back with backoff (about two minutes total) before failing.
+          max_attempts=10
+          promoted_latest=""
+          for (( attempt = 1; attempt <= max_attempts; attempt++ )); do
+            promoted_latest="$(npm view "${PACKAGE_NAME}" dist-tags.latest 2>/dev/null || true)"
+            if [[ "${promoted_latest}" == "${RELEASE_VERSION}" ]]; then
+              break
+            fi
+            if (( attempt == max_attempts )); then
+              echo "npm latest points at ${promoted_latest:-<unavailable>}, expected ${RELEASE_VERSION} after promotion (${max_attempts} attempts)." >&2
+              exit 1
+            fi
+            delay=$(( attempt * 3 ))
+            (( delay > 20 )) && delay=20
+            echo "npm latest still reports ${promoted_latest:-<unavailable>} (attempt ${attempt}/${max_attempts}); retrying in ${delay}s."
+            sleep "${delay}"
+          done
           echo "Promoted ${PACKAGE_NAME}@${RELEASE_VERSION} from beta to latest."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Lobster will be documented in this file.
 
 ## Unreleased
 
+- Retry the npm `latest` dist-tag read-back with backoff after promoting a beta release, so registry propagation delay no longer fails a promotion that already succeeded.
+
 ## 2026.9.5
 
 **Highlights:** Run configured OpenClaw agents directly from workflows, stop cancelled work before further side effects, and track LLM spend without charging cached answers again.


### PR DESCRIPTION
## Problem

The `promote_beta_to_latest` job runs `npm dist-tag add` and then immediately verifies with `npm view dist-tags.latest`. In [run 33993324703](https://github.com/openclaw/lobster/actions/runs/33993324703) the add succeeded (`+latest: @clawdbot/lobster@2026.9.5`), but the read-back still returned the previous `2026.6.11` because of registry propagation delay, so the job exited 1 even though npm reported `latest=2026.9.5` shortly afterwards.

## Fix

Poll the read-back with backoff before failing: up to 10 attempts with sleeps of 3, 6, 9, ... capped at 20s (about 123s total). The strict equality check is unchanged; a transient `npm view` failure counts as a miss rather than aborting the loop. Each miss logs the observed value and attempt number.

Also adds a CHANGELOG `Unreleased` bullet.

## Proof

- `actionlint` passes on the workflow.
- Loop exercised locally with a stubbed `npm`: immediate match succeeds without sleeping, a match on the 4th read succeeds after three sleeps, and a value that never matches exits 1 after 10 attempts with the expected error.
- Codex autoreview (P2 threshold): scoped-clean.

No tags or publishes involved.
