### PR TITLE
fix: preserve the executable after exec --json

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ conventional interrupt exit status.
 ## Commands
 
 - `exec`: run OS commands
+- `exec --json <command...>`: parse subprocess stdout as JSON before the next stage
 - `exec --stdin raw|json|jsonl`: feed pipeline input into subprocess stdin
 - `where`, `pick`, `head`: data shaping
 - `json`, `table`: renderers

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -118,7 +118,7 @@ function tokenizeCommand(input) {
 	return tokens;
 }
 
-function parseArgs(tokens) {
+function parseArgs(tokens, booleanFlags: readonly string[] = []) {
 	const args = { _: [] };
 
 	for (let i = 0; i < tokens.length; i++) {
@@ -135,7 +135,7 @@ function parseArgs(tokens) {
 
 			const key = tok.slice(2);
 			const next = tokens[i + 1];
-			if (!next || next.startsWith("--")) {
+			if (booleanFlags.includes(key) || !next || next.startsWith("--")) {
 				args[key] = true;
 				continue;
 			}
@@ -158,7 +158,8 @@ export function parsePipeline(input) {
 		const tokens = tokenizeCommand(stage);
 		if (tokens.length === 0) throw new Error("Empty command stage");
 		const name = tokens[0];
-		const args = parseArgs(tokens.slice(1));
+		// exec's JSON switch must not consume the child executable as its value.
+		const args = parseArgs(tokens.slice(1), name === "exec" ? ["json"] : []);
 		return { name, args, raw: stage };
 	});
 }

--- a/test/bin_smoke.test.ts
+++ b/test/bin_smoke.test.ts
@@ -12,3 +12,17 @@ test("packaged lobster bin starts and prints help", () => {
 	assert.equal(res.status, 0, res.stderr);
 	assert.match(res.stdout, /Usage:/);
 });
+
+test("packaged lobster exec --json preserves the child executable", () => {
+	const bin = path.join(process.cwd(), "bin", "lobster.js");
+	const pipeline = `exec --json "${process.execPath}" -p 'JSON.stringify([{n:1},{n:2}])' | where n>=2`;
+	const res = spawnSync(process.execPath, [bin, "run", "--mode", "tool", pipeline], {
+		encoding: "utf8",
+		timeout: 10_000,
+	});
+
+	assert.equal(res.status, 0, res.stderr || res.stdout);
+	const envelope = JSON.parse(res.stdout);
+	assert.equal(envelope.ok, true);
+	assert.deepEqual(envelope.output, [{ n: 2 }]);
+});

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -67,6 +67,25 @@ test("parsePipeline treats --flag followed by another --flag as boolean", () => 
 	assert.equal(p[0].args["out"], "file");
 });
 
+test("parsePipeline keeps the command after exec --json", () => {
+	for (const command of ["cat rows.json", "'echo [1,2,3]'"]) {
+		const stage = parsePipeline(`exec --json ${command}`)[0];
+		assert.equal(stage.args["json"], true);
+		assert.deepEqual(
+			stage.args._,
+			command.startsWith("'") ? ["echo [1,2,3]"] : ["cat", "rows.json"],
+		);
+	}
+});
+
+test("parsePipeline preserves value-taking options beside exec --json", () => {
+	const stage = parsePipeline("exec --stdin json --json cat")[0];
+	assert.equal(stage.args["stdin"], "json");
+	assert.equal(stage.args["json"], true);
+	assert.deepEqual(stage.args._, ["cat"]);
+	assert.equal(parsePipeline("custom --json payload")[0].args["json"], "payload");
+});
+
 test("parsePipeline unescapes \\$ and \\` inside double quotes", () => {
 	const p = parsePipeline('echo "\\$HOME \\`id\\`"');
 	assert.deepEqual(p[0].args._, ["$HOME `id`"]);


### PR DESCRIPTION
`exec --json cat rows.json` consumes `cat` as the value of the boolean JSON switch and then tries to execute `rows.json`. The same parsing error breaks the quoted command example shown by the CLI help.

Treat `exec`'s standalone `--json` as a boolean during pipeline parsing so the executable and its arguments stay positional. Preserve value-taking options and custom commands' existing argument parsing, document the direct form, and add parser plus real-bin regressions. The three new regressions fail on main before the parser fix.

Validation: Node 24, frozen pnpm install, typecheck, formatting/lint, full test suite, production build, and live production CLI pipelines. The live check also exercises the existing HTTP, Pi, and OpenClaw adapter routes against synthetic loopback fixtures; it makes no external inference calls. Independent Codex autoreview passed in local and branch modes through P2 with no actionable findings.

Changelog entry is consolidated in #158 (the final notes/tooling PR), to be merged after this fix.
