### PR TITLE
fix: honor timeout_ms, retry, and on_error on for_each steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Notes:
 - If you need a human checkpoint before an LLM call, use a dedicated `approval:` step in the workflow file rather than `approve` inside the nested pipeline.
 - `cwd`, `env`, `stdin`, `when`, and `condition` work for both shell and pipeline steps.
 - Use `retry`, `timeout_ms`, and `on_error` per step to control transient-failure behavior and recovery.
+- On `for_each`, these policies cover the entire loop: each attempt gets one timeout budget (including batch pauses), and retry restarts at the first item. Previously completed children may run again, so only enable loop retries for work that is safe to repeat. A `cost_limit` stop or an attempted OpenClaw dispatch prevents retries; paid LLM usage is checked even when a later pipeline command fails. `on_error: continue` records `$loop.error` and proceeds to the next workflow step; `skip_rest` skips the remaining workflow steps.
 - Approval steps can optionally enforce identity constraints:
   - `approval.required_approver` (or `requiredApprover`) requires an exact approver id.
   - `approval.require_different_approver` (or `requireDifferentApprover`) requires approver id to differ from initiator.

--- a/src/core/cost_tracker.ts
+++ b/src/core/cost_tracker.ts
@@ -18,6 +18,13 @@ export type CostLimit = {
 	action?: "warn" | "stop";
 };
 
+export class CostLimitExceededError extends Error {
+	constructor(estimatedCostUsd: number, maxUsd: number) {
+		super(`Cost limit exceeded: $${estimatedCostUsd.toFixed(4)} > $${maxUsd.toFixed(2)} limit`);
+		this.name = "CostLimitExceededError";
+	}
+}
+
 const DEFAULT_PRICING: Record<string, { input: number; output: number }> = {
 	"gpt-4o": { input: 2.5, output: 10.0 },
 	"gpt-4o-mini": { input: 0.15, output: 0.6 },
@@ -138,9 +145,7 @@ export class CostTracker {
 		if (summary.estimatedCostUsd <= limit.max_usd) return;
 
 		if (limit.action === "stop") {
-			throw new Error(
-				`Cost limit exceeded: $${summary.estimatedCostUsd.toFixed(4)} > $${limit.max_usd.toFixed(2)} limit`,
-			);
+			throw new CostLimitExceededError(summary.estimatedCostUsd, limit.max_usd);
 		}
 
 		if (stderr) {

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -34,7 +34,7 @@ import type {
 	LlmOutstandingCharge,
 	LlmSpendLedger,
 } from "../commands/stdlib/llm_invoke.js";
-import { CostTracker } from "../core/cost_tracker.js";
+import { CostLimitExceededError, CostTracker } from "../core/cost_tracker.js";
 import type { CostLimit, CostSummary } from "../core/cost_tracker.js";
 import { withRetry, resolveRetryConfig } from "../core/retry.js";
 import type { RetryConfig } from "../core/retry.js";
@@ -1605,7 +1605,8 @@ export async function runWorkflowFile({
 								shouldRetry: (error) => {
 									if (
 										error instanceof WorkflowPipelineInputSuspension ||
-										error instanceof RequestInputResumeError
+										error instanceof RequestInputResumeError ||
+										error instanceof CostLimitExceededError
 									) {
 										return false;
 									}
@@ -1699,6 +1700,9 @@ export async function runWorkflowFile({
 					}
 				}
 				if (err instanceof RequestInputResumeError) {
+					throw err;
+				}
+				if (err instanceof CostLimitExceededError) {
 					throw err;
 				}
 				if (ctx.signal?.aborted) {

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -1613,6 +1613,12 @@ export async function runWorkflowFile({
 									if (isStepErrorNonRetryable(error)) {
 										return false;
 									}
+									if (ctx.signal?.aborted) return false;
+									if (workflow.cost_limit?.action === "stop") {
+										// Failed pipelines can discard output after the provider was paid.
+										settleUnbilledCharges(costTracker, llmSpendLedger);
+										costTracker.checkLimit(workflow.cost_limit, ctx.stderr);
+									}
 									const message = error?.message ?? String(error);
 									return !/halted (for approval inside|before completion at) pipeline/.test(
 										message,

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -1128,139 +1128,6 @@ export async function runWorkflowFile({
 				continue;
 			}
 
-			if (typeof step.for_each === "string" && Array.isArray(step.steps)) {
-				const itemsRef = resolveInputValue(step.for_each, resolvedArgs, results);
-				if (!Array.isArray(itemsRef)) {
-					throw new Error(
-						`Workflow step ${step.id} for_each: expected array, got ${typeof itemsRef}`,
-					);
-				}
-
-				const itemVar = step.item_var ?? "item";
-				const indexVar = step.index_var ?? "index";
-				const batchSize = step.batch_size ?? 1;
-				const iterationResults: unknown[] = [];
-
-				for (let itemIdx = 0; itemIdx < itemsRef.length; itemIdx++) {
-					ctx.signal?.throwIfAborted();
-					if (step.pause_ms && itemIdx > 0 && itemIdx % batchSize === 0) {
-						await abortableSleep(step.pause_ms, ctx.signal);
-					}
-
-					const item = itemsRef[itemIdx];
-					const scopedResults = createRecord(results);
-					scopedResults[itemVar] = {
-						id: itemVar,
-						json: item,
-						stdout: typeof item === "string" ? item : JSON.stringify(item),
-					};
-					scopedResults[indexVar] = {
-						id: indexVar,
-						json: itemIdx,
-						stdout: String(itemIdx),
-					};
-
-					for (const subStep of step.steps) {
-						ctx.signal?.throwIfAborted();
-						if (!evaluateCondition(subStep.when ?? subStep.condition, scopedResults)) {
-							scopedResults[subStep.id] = { id: subStep.id, skipped: true };
-							continue;
-						}
-
-						const loopEnvBase = mergeEnv(
-							ctx.env,
-							workflow.env,
-							step.env,
-							resolvedArgs,
-							scopedResults,
-						);
-						const subEnv = subStep.env
-							? mergeEnv(loopEnvBase, undefined, subStep.env, resolvedArgs, scopedResults)
-							: loopEnvBase;
-						const subCwd =
-							resolveCwd(subStep.cwd ?? step.cwd ?? workflow.cwd, resolvedArgs) ?? ctx.cwd;
-						const subExecution = getStepExecution(subStep);
-
-						let subResult: WorkflowStepResult;
-						if (subExecution.kind === "shell") {
-							const command = resolveTemplate(subExecution.value, resolvedArgs, scopedResults);
-							const stdinValue = resolveShellStdin(subStep.stdin, resolvedArgs, scopedResults);
-							await markExecutionStarted(ctx.signal);
-							const { stdout } = await runShellCommand({
-								command,
-								stdin: stdinValue,
-								env: subEnv,
-								cwd: subCwd,
-								signal: ctx.signal,
-								forceTerminationSignal: ctx.forceTerminationSignal,
-							});
-							subResult = { id: subStep.id, stdout, json: parseJson(stdout) };
-						} else if (subExecution.kind === "pipeline") {
-							if (!ctx.registry) {
-								throw new Error(
-									`Workflow step ${step.id} for_each sub-step ${subStep.id} requires a command registry for pipeline execution`,
-								);
-							}
-							const pipelineText = resolveTemplate(subExecution.value, resolvedArgs, scopedResults);
-							const inputValue = resolveInputValue(subStep.stdin, resolvedArgs, scopedResults);
-							subResult = await runPipelineStep({
-								stepId: subStep.id,
-								pipelineText,
-								inputValue,
-								ctx,
-								llmSpendLedger,
-								env: subEnv,
-								cwd: subCwd,
-								requestInputEnabled: false,
-								onExecutionStart: () => markExecutionStarted(ctx.signal),
-							});
-						} else {
-							const inputValue = resolveInputValue(subStep.stdin, resolvedArgs, scopedResults);
-							subResult = createSyntheticStepResult(subStep.id, inputValue);
-						}
-
-						scopedResults[subStep.id] = subResult;
-						trackStepCost(costTracker, `${step.id}.${subStep.id}`, subResult, llmSpendLedger);
-						// Before the next step runs: a charge no item carried is spend the step really made,
-						// and leaving it for the end would let `cost_limit` wave through every step after the
-						// one that blew the budget.
-						settleUnbilledCharges(costTracker, llmSpendLedger);
-						if (workflow.cost_limit) {
-							costTracker.checkLimit(workflow.cost_limit, ctx.stderr);
-						}
-					}
-
-					const iterResult = createRecord<unknown>();
-					iterResult[itemVar] = item;
-					iterResult[indexVar] = itemIdx;
-					for (const subStep of step.steps) {
-						const subResult = scopedResults[subStep.id];
-						if (subResult && !subResult.skipped) {
-							iterResult[subStep.id] =
-								subResult.json !== undefined ? subResult.json : subResult.stdout;
-						}
-					}
-					iterationResults.push(Object.fromEntries(Object.entries(iterResult)));
-				}
-
-				const loopResult: WorkflowStepResult = {
-					id: step.id,
-					json: iterationResults,
-					stdout: JSON.stringify(iterationResults),
-				};
-				results[step.id] = loopResult;
-				lastStepId = step.id;
-				trackStepCost(costTracker, step.id, loopResult, llmSpendLedger);
-				// Before the next step runs: a charge no item carried is spend the step really made,
-				// and leaving it for the end would let `cost_limit` wave through every step after the
-				// one that blew the budget.
-				settleUnbilledCharges(costTracker, llmSpendLedger);
-				if (workflow.cost_limit) {
-					costTracker.checkLimit(workflow.cost_limit, ctx.stderr);
-				}
-				continue;
-			}
-
 			const env = mergeEnv(ctx.env, workflow.env, step.env, resolvedArgs, results);
 			const cwd = resolveCwd(step.cwd ?? workflow.cwd, resolvedArgs) ?? ctx.cwd;
 			const execution = getStepExecution(step);
@@ -1297,7 +1164,139 @@ export async function runWorkflowFile({
 				let result: WorkflowStepResult;
 				let parallelBranchResults: Record<string, WorkflowStepResult> | null = null;
 				try {
-					if (execution.kind === "parallel") {
+					if (typeof step.for_each === "string" && Array.isArray(step.steps)) {
+						const itemsRef = resolveInputValue(step.for_each, resolvedArgs, results);
+						if (!Array.isArray(itemsRef)) {
+							throw new Error(
+								`Workflow step ${step.id} for_each: expected array, got ${typeof itemsRef}`,
+							);
+						}
+
+						const itemVar = step.item_var ?? "item";
+						const indexVar = step.index_var ?? "index";
+						const batchSize = step.batch_size ?? 1;
+						const iterationResults: unknown[] = [];
+
+						for (let itemIdx = 0; itemIdx < itemsRef.length; itemIdx++) {
+							stepSignal?.throwIfAborted();
+							if (step.pause_ms && itemIdx > 0 && itemIdx % batchSize === 0) {
+								await abortableSleep(step.pause_ms, stepSignal);
+							}
+
+							const item = itemsRef[itemIdx];
+							const scopedResults = createRecord(results);
+							scopedResults[itemVar] = {
+								id: itemVar,
+								json: item,
+								stdout: typeof item === "string" ? item : JSON.stringify(item),
+							};
+							scopedResults[indexVar] = {
+								id: indexVar,
+								json: itemIdx,
+								stdout: String(itemIdx),
+							};
+
+							for (const subStep of step.steps) {
+								stepSignal?.throwIfAborted();
+								if (!evaluateCondition(subStep.when ?? subStep.condition, scopedResults)) {
+									scopedResults[subStep.id] = { id: subStep.id, skipped: true };
+									continue;
+								}
+
+								const loopEnvBase = mergeEnv(
+									ctx.env,
+									workflow.env,
+									step.env,
+									resolvedArgs,
+									scopedResults,
+								);
+								const subEnv = subStep.env
+									? mergeEnv(loopEnvBase, undefined, subStep.env, resolvedArgs, scopedResults)
+									: loopEnvBase;
+								const subCwd =
+									resolveCwd(subStep.cwd ?? step.cwd ?? workflow.cwd, resolvedArgs) ?? ctx.cwd;
+								const subExecution = getStepExecution(subStep);
+
+								let subResult: WorkflowStepResult;
+								if (subExecution.kind === "shell") {
+									const command = resolveTemplate(subExecution.value, resolvedArgs, scopedResults);
+									const stdinValue = resolveShellStdin(subStep.stdin, resolvedArgs, scopedResults);
+									await markExecutionStarted(stepSignal);
+									const { stdout } = await runShellCommand({
+										command,
+										stdin: stdinValue,
+										env: subEnv,
+										cwd: subCwd,
+										signal: stepSignal,
+										forceTerminationSignal: ctx.forceTerminationSignal,
+										killSignal: () =>
+											stepTimeoutController?.signal.aborted
+												? ("SIGKILL" as NodeJS.Signals)
+												: undefined,
+									});
+									subResult = { id: subStep.id, stdout, json: parseJson(stdout) };
+								} else if (subExecution.kind === "pipeline") {
+									if (!ctx.registry) {
+										throw new Error(
+											`Workflow step ${step.id} for_each sub-step ${subStep.id} requires a command registry for pipeline execution`,
+										);
+									}
+									const pipelineText = resolveTemplate(
+										subExecution.value,
+										resolvedArgs,
+										scopedResults,
+									);
+									const inputValue = resolveInputValue(subStep.stdin, resolvedArgs, scopedResults);
+									subResult = await runPipelineStep({
+										stepId: subStep.id,
+										pipelineText,
+										inputValue,
+										ctx: {
+											...ctx,
+											signal: stepSignal,
+											_onNonRetryableSideEffect: markNonRetryableSideEffect,
+										},
+										llmSpendLedger,
+										env: subEnv,
+										cwd: subCwd,
+										requestInputEnabled: false,
+										onExecutionStart: () => markExecutionStarted(stepSignal),
+									});
+								} else {
+									const inputValue = resolveInputValue(subStep.stdin, resolvedArgs, scopedResults);
+									subResult = createSyntheticStepResult(subStep.id, inputValue);
+								}
+
+								scopedResults[subStep.id] = subResult;
+								trackStepCost(costTracker, `${step.id}.${subStep.id}`, subResult, llmSpendLedger);
+								// Before the next step runs: a charge no item carried is spend the step really made,
+								// and leaving it for the end would let `cost_limit` wave through every step after the
+								// one that blew the budget.
+								settleUnbilledCharges(costTracker, llmSpendLedger);
+								if (workflow.cost_limit) {
+									costTracker.checkLimit(workflow.cost_limit, ctx.stderr);
+								}
+							}
+
+							const iterResult = createRecord<unknown>();
+							iterResult[itemVar] = item;
+							iterResult[indexVar] = itemIdx;
+							for (const subStep of step.steps) {
+								const subResult = scopedResults[subStep.id];
+								if (subResult && !subResult.skipped) {
+									iterResult[subStep.id] =
+										subResult.json !== undefined ? subResult.json : subResult.stdout;
+								}
+							}
+							iterationResults.push(Object.fromEntries(Object.entries(iterResult)));
+						}
+
+						result = {
+							id: step.id,
+							json: iterationResults,
+							stdout: JSON.stringify(iterationResults),
+						};
+					} else if (execution.kind === "parallel") {
 						const parallel = execution.value;
 						const wait = parallel.wait ?? "all";
 						const branchAbortController = new AbortController();
@@ -2077,6 +2076,16 @@ function dryRunWorkflow({
 					lines.push(`       ${subIdx + 1}. ${sub.id}  [no-op]`);
 				}
 				loopScopedResults[sub.id] = { id: sub.id };
+			}
+			if (step.timeout_ms) lines.push(`     timeout: ${step.timeout_ms}ms`);
+			if (step.on_error && step.on_error !== "stop") lines.push(`     on_error: ${step.on_error}`);
+			if (step.retry && typeof step.retry === "object") {
+				const rc = resolveRetryConfig(step.retry as RetryConfig);
+				if (rc.max > 1) {
+					lines.push(
+						`     retry: up to ${rc.max} attempts, ${rc.backoff} backoff (base: ${rc.delay_ms}ms${rc.jitter ? ", jitter" : ""})`,
+					);
+				}
 			}
 			results[step.id] = { id: step.id };
 			continue;

--- a/test/cost_tracker.test.ts
+++ b/test/cost_tracker.test.ts
@@ -2366,3 +2366,51 @@ test("workflow cost tracking leaves a discarded wait:any branch out of the total
 		running.result._meta?.cost?.totalInputTokens,
 	);
 });
+
+for (const loop of [false, true]) {
+	test(`cost_limit stops ${loop ? "for_each" : "pipeline"} retries after a paid call loses its output`, async () => {
+		let calls = 0;
+		const step = {
+			id: "spend",
+			pipeline:
+				'llm.invoke --provider budget-test --model gpt-4o --prompt test --refresh --disable-cache | exec --stdin json node -e "process.exit(1)"',
+		};
+		const retry = { max: 3, delay_ms: 1 };
+		await assert.rejects(
+			() =>
+				runWorkflow(
+					{
+						cost_limit: { max_usd: 0.001, action: "stop" },
+						steps: loop
+							? [
+									{ id: "data", pipeline: "exec --json node -e \"console.log('[1,2]')\"" },
+									{
+										id: "loop",
+										for_each: "$data.json",
+										retry,
+										on_error: "continue",
+										steps: [step],
+									},
+								]
+							: [{ ...step, retry, on_error: "continue" }],
+					},
+					undefined,
+					{
+						"budget-test": async () => {
+							calls++;
+							return {
+								ok: true,
+								result: {
+									output: { text: "paid" },
+									model: "gpt-4o",
+									usage: { inputTokens: 1000, outputTokens: 500 },
+								},
+							};
+						},
+					},
+				),
+			/Cost limit exceeded/,
+		);
+		assert.equal(calls, 1, "a downstream failure must not hide paid usage from the retry budget");
+	});
+}

--- a/test/for_each.test.ts
+++ b/test/for_each.test.ts
@@ -282,3 +282,212 @@ test("for_each dry-run renders loop structure", async () => {
 	assert.match(out, /sub-steps: 1/);
 	assert.match(out, /batch_size: 2/);
 });
+
+async function writeNodeCommand(tmpDir: string, name: string, source: string) {
+	const filePath = path.join(tmpDir, name);
+	await fsp.writeFile(filePath, source, "utf8");
+	return `node ${filePath.split(path.sep).join("/")}`;
+}
+
+async function runWorkflowWithIo(workflow: unknown) {
+	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-foreach-"));
+	const stateDir = path.join(tmpDir, "state");
+	const filePath = path.join(tmpDir, "workflow.lobster");
+	await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), "utf8");
+
+	const stderr = new PassThrough();
+	const chunks: string[] = [];
+	stderr.on("data", (chunk: Buffer | string) => chunks.push(String(chunk)));
+
+	const result = await runWorkflowFile({
+		filePath,
+		ctx: {
+			stdin: process.stdin,
+			stdout: process.stdout,
+			stderr,
+			env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+			mode: "tool",
+			registry: createDefaultRegistry(),
+		},
+	});
+	return { result, stderrOutput: chunks.join("") };
+}
+
+test("for_each timeout_ms aborts a hanging child step", async () => {
+	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-foreach-timeout-"));
+	const dataCmd = await writeNodeCommand(
+		tmpDir,
+		"data.js",
+		"process.stdout.write(JSON.stringify([1]));\n",
+	);
+	const hangCmd = await writeNodeCommand(tmpDir, "hang.js", "setTimeout(() => {}, 5000);\n");
+
+	await assert.rejects(
+		() =>
+			runWorkflow({
+				steps: [
+					{ id: "data", command: dataCmd },
+					{
+						id: "loop",
+						for_each: "$data.json",
+						timeout_ms: 200,
+						steps: [{ id: "slow", command: hangCmd }],
+					},
+				],
+			}),
+		/timed out after 200ms/,
+	);
+});
+
+test("for_each timeout_ms with on_error continue records error and continues", async () => {
+	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-foreach-timeout-continue-"));
+	const dataCmd = await writeNodeCommand(
+		tmpDir,
+		"data.js",
+		"process.stdout.write(JSON.stringify([1]));\n",
+	);
+	const hangCmd = await writeNodeCommand(tmpDir, "hang.js", "setTimeout(() => {}, 5000);\n");
+	const checkCmd = await writeNodeCommand(
+		tmpDir,
+		"check.js",
+		"process.stdout.write(JSON.stringify({saw: process.env.SAW}));\n",
+	);
+
+	const result = await runWorkflow({
+		steps: [
+			{ id: "data", command: dataCmd },
+			{
+				id: "loop",
+				for_each: "$data.json",
+				timeout_ms: 200,
+				on_error: "continue",
+				steps: [{ id: "slow", command: hangCmd }],
+			},
+			{
+				id: "check",
+				command: checkCmd,
+				env: { SAW: "$loop.error" },
+			},
+		],
+	});
+	assert.equal(result.status, "ok");
+	assert.deepEqual(result.output, [{ saw: "true" }]);
+});
+
+test("for_each on_error continue records a child command failure and continues", async () => {
+	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-foreach-onerror-"));
+	const dataCmd = await writeNodeCommand(
+		tmpDir,
+		"data.js",
+		"process.stdout.write(JSON.stringify([1]));\n",
+	);
+	const failCmd = await writeNodeCommand(tmpDir, "fail.js", "process.exit(1);\n");
+	const checkCmd = await writeNodeCommand(
+		tmpDir,
+		"check.js",
+		"process.stdout.write(JSON.stringify({saw: process.env.SAW}));\n",
+	);
+
+	const result = await runWorkflow({
+		steps: [
+			{ id: "data", command: dataCmd },
+			{
+				id: "loop",
+				for_each: "$data.json",
+				on_error: "continue",
+				steps: [{ id: "fail", command: failCmd }],
+			},
+			{
+				id: "check",
+				command: checkCmd,
+				env: { SAW: "$loop.error" },
+			},
+		],
+	});
+	assert.equal(result.status, "ok");
+	assert.deepEqual(result.output, [{ saw: "true" }]);
+});
+
+test("for_each retry retries a failing child and then succeeds", async () => {
+	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-foreach-retry-"));
+	const counterFile = path.join(tmpDir, "counter");
+	await fsp.writeFile(counterFile, "0", "utf8");
+	const dataCmd = await writeNodeCommand(
+		tmpDir,
+		"data.js",
+		"process.stdout.write(JSON.stringify([1]));\n",
+	);
+	const flakyCmd = await writeNodeCommand(
+		tmpDir,
+		"flaky.js",
+		[
+			'const fs = require("fs");',
+			`const p = ${JSON.stringify(counterFile)};`,
+			'const c = Number(fs.readFileSync(p, "utf8")) + 1;',
+			"fs.writeFileSync(p, String(c));",
+			"if (c < 3) process.exit(1);",
+			"process.stdout.write(JSON.stringify({ attempt: c }));",
+			"",
+		].join("\n"),
+	);
+
+	const { result, stderrOutput } = await runWorkflowWithIo({
+		steps: [
+			{ id: "data", command: dataCmd },
+			{
+				id: "loop",
+				for_each: "$data.json",
+				retry: { max: 3, delay_ms: 20 },
+				steps: [{ id: "flaky", command: flakyCmd }],
+			},
+		],
+	});
+	assert.equal(result.status, "ok");
+	assert.deepEqual(result.output, [{ item: 1, index: 0, flaky: { attempt: 3 } }]);
+	assert.ok(stderrOutput.includes("[RETRY]"), "should log retry attempts");
+});
+
+test("for_each dry-run renders timeout, retry, and on_error", async () => {
+	const workflow = {
+		steps: [
+			{ id: "vals", command: 'node -e "process.stdout.write(JSON.stringify([1]))"' },
+			{
+				id: "loop",
+				for_each: "$vals.json",
+				timeout_ms: 1500,
+				on_error: "continue",
+				retry: { max: 3, backoff: "fixed", delay_ms: 100 },
+				steps: [{ id: "emit", command: "echo hi" }],
+			},
+		],
+	};
+
+	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-foreach-"));
+	const stateDir = path.join(tmpDir, "state");
+	const filePath = path.join(tmpDir, "workflow.lobster");
+	await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), "utf8");
+
+	const stderr = new PassThrough();
+	let out = "";
+	stderr.on("data", (d: Buffer | string) => {
+		out += String(d);
+	});
+
+	await runWorkflowFile({
+		filePath,
+		ctx: {
+			stdin: process.stdin,
+			stdout: process.stdout,
+			stderr,
+			env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+			mode: "tool",
+			dryRun: true,
+			registry: createDefaultRegistry(),
+		},
+	});
+
+	assert.match(out, /\[for_each\]/);
+	assert.match(out, /timeout: 1500ms/);
+	assert.match(out, /on_error: continue/);
+	assert.match(out, /retry: up to 3 attempts/);
+});

--- a/test/for_each.test.ts
+++ b/test/for_each.test.ts
@@ -313,31 +313,38 @@ async function runWorkflowWithIo(workflow: unknown) {
 	return { result, stderrOutput: chunks.join("") };
 }
 
-test("for_each timeout_ms aborts a hanging child step", async () => {
-	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-foreach-timeout-"));
-	const dataCmd = await writeNodeCommand(
-		tmpDir,
-		"data.js",
-		"process.stdout.write(JSON.stringify([1]));\n",
-	);
-	const hangCmd = await writeNodeCommand(tmpDir, "hang.js", "setTimeout(() => {}, 5000);\n");
+for (const pipeline of [false, true]) {
+	test(`for_each timeout_ms aborts a hanging ${pipeline ? "pipeline" : "shell"} child`, async (t) => {
+		const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-foreach-timeout-"));
+		t.after(() => fsp.rm(tmpDir, { recursive: true, force: true }));
+		const dataCmd = await writeNodeCommand(
+			tmpDir,
+			"data.js",
+			"process.stdout.write(JSON.stringify([1]));\n",
+		);
+		const hangCmd = await writeNodeCommand(tmpDir, "hang.js", "setTimeout(() => {}, 5000);\n");
 
-	await assert.rejects(
-		() =>
-			runWorkflow({
-				steps: [
-					{ id: "data", command: dataCmd },
-					{
-						id: "loop",
-						for_each: "$data.json",
-						timeout_ms: 200,
-						steps: [{ id: "slow", command: hangCmd }],
-					},
-				],
-			}),
-		/timed out after 200ms/,
-	);
-});
+		await assert.rejects(
+			() =>
+				runWorkflow({
+					steps: [
+						{ id: "data", command: dataCmd },
+						{
+							id: "loop",
+							for_each: "$data.json",
+							timeout_ms: 200,
+							steps: [
+								pipeline
+									? { id: "slow", pipeline: `exec ${hangCmd}` }
+									: { id: "slow", command: hangCmd },
+							],
+						},
+					],
+				}),
+			/timed out after 200ms/,
+		);
+	});
+}
 
 test("for_each timeout_ms with on_error continue records error and continues", async () => {
 	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-foreach-timeout-continue-"));
@@ -532,3 +539,69 @@ test("for_each dry-run renders timeout, retry, and on_error", async () => {
 	assert.match(out, /on_error: continue/);
 	assert.match(out, /retry: up to 3 attempts/);
 });
+
+test("for_each retries restart at the first item after a later item fails", async (t) => {
+	const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-foreach-restart-"));
+	t.after(() => fsp.rm(dir, { recursive: true, force: true }));
+	const history = path.join(dir, "history.json");
+	const command = await writeNodeCommand(
+		dir,
+		"flaky.cjs",
+		`
+const fs = require("node:fs");
+const file = ${JSON.stringify(history)};
+const history = fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, "utf8")) : [];
+const item = Number(process.env.ITEM);
+history.push(item);
+fs.writeFileSync(file, JSON.stringify(history));
+if (history.length === 2) process.exit(1);
+console.log(item);
+`,
+	);
+	const result = await runWorkflow({
+		steps: [
+			{ id: "data", run: "node -e \"console.log('[1,2]')\"" },
+			{
+				id: "loop",
+				for_each: "$data.json",
+				retry: { max: 2, delay_ms: 1 },
+				steps: [{ id: "child", run: command, env: { ITEM: "$item.json" } }],
+			},
+		],
+	});
+	assert.equal(result.status, "ok");
+	assert.deepEqual(JSON.parse(await fsp.readFile(history, "utf8")), [1, 2, 1, 2]);
+	assert.deepEqual(result.output, [
+		{ item: 1, index: 0, child: 1 },
+		{ item: 2, index: 1, child: 2 },
+	]);
+});
+
+for (const customNames of [false, true]) {
+	test(`for_each resolves loop environment per item with ${customNames ? "custom" : "default"} names`, async () => {
+		const itemVar = customNames ? "value" : "item";
+		const indexVar = customNames ? "position" : "index";
+		const result = await runWorkflow({
+			steps: [
+				{ id: "data", run: "node -e \"console.log('[10,20]')\"" },
+				{
+					id: "loop",
+					for_each: "$data.json",
+					item_var: itemVar,
+					index_var: indexVar,
+					env: { ITEM: `$${itemVar}.json`, INDEX: `$${indexVar}.json` },
+					steps: [
+						{
+							id: "read",
+							run: 'node -e "console.log(JSON.stringify({item:process.env.ITEM,index:process.env.INDEX}))"',
+						},
+					],
+				},
+			],
+		});
+		assert.deepEqual(result.output, [
+			{ [itemVar]: 10, [indexVar]: 0, read: { item: "10", index: "0" } },
+			{ [itemVar]: 20, [indexVar]: 1, read: { item: "20", index: "1" } },
+		]);
+	});
+}

--- a/test/for_each.test.ts
+++ b/test/for_each.test.ts
@@ -447,6 +447,47 @@ test("for_each retry retries a failing child and then succeeds", async () => {
 	assert.ok(stderrOutput.includes("[RETRY]"), "should log retry attempts");
 });
 
+test("for_each cost_limit stop does not retry a child that already exceeded the budget", async () => {
+	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-foreach-cost-stop-"));
+	const counterFile = path.join(tmpDir, "counter");
+	await fsp.writeFile(counterFile, "0", "utf8");
+	const dataCmd = await writeNodeCommand(
+		tmpDir,
+		"data.js",
+		"process.stdout.write(JSON.stringify([1, 2]));\n",
+	);
+	const spendCmd = await writeNodeCommand(
+		tmpDir,
+		"spend.js",
+		[
+			'const fs = require("fs");',
+			`const p = ${JSON.stringify(counterFile)};`,
+			'const c = Number(fs.readFileSync(p, "utf8")) + 1;',
+			"fs.writeFileSync(p, String(c));",
+			"process.stdout.write(JSON.stringify({model:'gpt-4o',usage:{inputTokens:1000,outputTokens:1000}}));",
+			"",
+		].join("\n"),
+	);
+
+	await assert.rejects(
+		() =>
+			runWorkflowWithIo({
+				cost_limit: { max_usd: 0.01, action: "stop" },
+				steps: [
+					{ id: "data", command: dataCmd },
+					{
+						id: "loop",
+						for_each: "$data.json",
+						retry: { max: 3, delay_ms: 20 },
+						steps: [{ id: "spend", command: spendCmd }],
+					},
+				],
+			}),
+		/Cost limit exceeded/,
+	);
+	assert.equal(await fsp.readFile(counterFile, "utf8"), "1");
+});
+
 test("for_each dry-run renders timeout, retry, and on_error", async () => {
 	const workflow = {
 		steps: [


### PR DESCRIPTION
`for_each` accepted `timeout_ms`, `retry`, and `on_error` but executed before the shared step-policy wrapper. A loop with two 1.5-second children and a 200 ms timeout therefore succeeded after more than three seconds. Moving the loop into the shared attempt path makes shell and pipeline children, batch pauses, retries, and error recovery honor those settings.

Policies apply to the entire loop: a retry starts at the first item, including previously completed children. The README now makes that replay behavior explicit. External cancellation still stops the workflow, and attempted OpenClaw dispatch suppresses retries even when a later child fails.

Budget stops remain terminal. A typed budget error bypasses retry and `on_error`, and the maintainer follow-up checks outstanding paid LLM usage before retrying a failed pipeline. Without that check, a provider could answer and a later stage fail, causing three paid calls before a budget stop. Both ordinary pipeline steps and loop children now stop after the first over-budget call.

Validation on macOS with Node 24:

- `pnpm typecheck`, `pnpm lint`, `pnpm test`, and `pnpm build` passed. Full suite: 633 tests, 630 passed, three existing skips, no failures. Lint retains seven existing warnings.
- Built `node bin/lobster.js run --mode tool --file ...`: reproduced ignored shell and pipeline timeouts on main; verified timeout errors, `on_error: continue`, `skip_rest`, whole-loop retries, and dry-run policy output after the fix.
- Built CLI with a local synthetic HTTP adapter: over-budget downstream failures made three provider calls before the maintainer fix and one afterward, for both ordinary and loop pipelines. No billed model calls were used.
- Built CLI: batch pauses respect the loop timeout, each retry gets a new timeout, and external SIGINT exits 130 after terminating the child, with no retry or later step.
- Built CLI with a local synthetic OpenClaw endpoint: a successful dispatch followed by a failing child made exactly one request despite `retry.max: 3`.
- Added regression coverage for pipeline-child timeouts, replay of earlier loop items, hidden paid usage before retry, and loop-level environment references with default/custom item names.

Changelog entries are prepared separately in the final release-notes PR so this branch remains independent of other changes.
