### PR TITLE
docs: prepare 2026.9.8 patch release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Lobster will be documented in this file.
 
 ## Unreleased
 
+**Highlights:** Workflow loops honor their execution policies, and paid LLM calls cannot hide from budget checks when a later pipeline command fails.
+
+- Honor `timeout_ms`, `retry`, and `on_error` on `for_each` steps, including pipeline children and batch pauses; document whole-loop replay and show policies in dry runs. Thanks @SebTardif (PR [#160](https://github.com/openclaw/lobster/pull/160)).
+- Stop retries and error recovery after a `cost_limit` stop, including paid LLM usage discarded by a failed pipeline, preventing additional over-budget calls. Thanks @SebTardif (PR [#160](https://github.com/openclaw/lobster/pull/160)).
+
 ## 2026.9.7 - 2026-09-07
 
 **Highlights:** Direct `exec --json` commands now preserve their executable, alongside more reliable npm release promotion.


### PR DESCRIPTION
Prepare the complete Unreleased section for the next CalVer patch, 2026.9.8, covering #160: loop timeout/retry/error policies and budget enforcement before retrying paid work.

Merge #160 first, then this notes-only PR. Both branches start from main independently; only this branch changes CHANGELOG.md. All released sections are unchanged. No version bump, tag, or publication is included.

Dependency verification found no stale pnpm packages; pnpm 12.3.4 and the checked GitHub Actions are current. The existing two-day minimum release age remains unchanged.

The runtime candidate passed the full Node 24 suite (630 passed, three existing skips), typecheck, lint, build, and real CLI before/after probes for shell/pipeline timeouts, retries, error policies, cancellation, dispatch replay prevention, and synthetic HTTP provider spending. The release still needs merged-main CI and an authorized beta-first npm preflight/publish/promotion, plus a GitHub release.
