### PR TITLE
fix(sdk): restore shell process separation

### DIFF
--- a/src/sdk/primitives/exec.ts
+++ b/src/sdk/primitives/exec.ts
@@ -10,36 +10,12 @@
  */
 
 import { runAbortableProcess } from "../../abortable_process.js";
-import { resolveInlineShellCommand } from "../../shell.js";
-
-/**
- * Run a process and capture output
- * @param {string} command
- * @param {string[]} argv
- * @param {Object} options
- * @returns {Promise<{stdout: string, stderr: string}>}
- */
-async function runProcess(command, argv, { env, cwd, signal, forceTerminationSignal }) {
-	const { stdout, stderr, code } = await runAbortableProcess({
-		command,
-		argv,
-		env,
-		cwd,
-		signal,
-		forceTerminationSignal,
-		notFoundMessage: `Failed to execute ${command}: spawn ${command} ENOENT`,
-	});
-	if (code === 0) {
-		return { stdout, stderr };
-	}
-	throw new Error(`${command} exited with code ${code}: ${stderr.trim() || stdout.trim()}`);
-}
 
 /**
  * Parse a shell command string into command and arguments
  * Simple parsing - for complex cases, use options.shell
  * @param {string} cmdString
- * @returns {{command: string, args: string[]}}
+ * @returns {{command: string, argv: string[]}}
  */
 function parseCommand(cmdString) {
 	const tokens = [];
@@ -83,8 +59,8 @@ function parseCommand(cmdString) {
 		tokens.push(current);
 	}
 
-	const [command, ...args] = tokens;
-	return { command, args };
+	const [command, ...argv] = tokens;
+	return { command, argv };
 }
 
 /**
@@ -113,26 +89,20 @@ export function exec(cmdString, options: any = {}) {
 			}
 
 			const env = ctx.env ?? process.env;
-
-			let stdout;
-
-			const processOptions = {
+			const invocation = useShell ? { shellCommand: cmdString } : parseCommand(cmdString);
+			const command = "command" in invocation ? invocation.command : cmdString;
+			const { stdout, stderr, code } = await runAbortableProcess({
+				...invocation,
 				env,
 				cwd,
 				signal: ctx.signal,
 				forceTerminationSignal: ctx.forceTerminationSignal,
-			};
-
-			if (useShell) {
-				// Shell execution
-				const shell = resolveInlineShellCommand({ command: cmdString, env });
-				const result = await runProcess(shell.command, shell.argv, processOptions);
-				stdout = result.stdout;
-			} else {
-				// Direct execution
-				const { command, args } = parseCommand(cmdString);
-				const result = await runProcess(command, args, processOptions);
-				stdout = result.stdout;
+				notFoundMessage: useShell
+					? "exec shell not found; check LOBSTER_SHELL or ComSpec"
+					: `Failed to execute ${command}: spawn ${command} ENOENT`,
+			});
+			if (code !== 0) {
+				throw new Error(`${command} exited with code ${code}: ${stderr.trim() || stdout.trim()}`);
 			}
 
 			// Parse output

--- a/test/helpers/node_shell_fixture.ts
+++ b/test/helpers/node_shell_fixture.ts
@@ -1,0 +1,18 @@
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export async function nodeShellFixture(dir: string, script: string) {
+	const scriptPath = join(dir, "script.cjs");
+	await writeFile(scriptPath, script);
+	return {
+		command:
+			process.platform === "win32"
+				? '"%LOBSTER_TEST_NODE%" "%LOBSTER_TEST_SCRIPT%"'
+				: '"$LOBSTER_TEST_NODE" "$LOBSTER_TEST_SCRIPT"',
+		env: {
+			LOBSTER_SHELL: process.platform === "win32" ? "cmd.exe" : "/bin/sh",
+			LOBSTER_TEST_NODE: process.execPath,
+			LOBSTER_TEST_SCRIPT: scriptPath,
+		},
+	};
+}

--- a/test/process_output_limit.test.ts
+++ b/test/process_output_limit.test.ts
@@ -8,6 +8,7 @@ import { promisify } from "node:util";
 import { Lobster, exec } from "../src/sdk/index.js";
 import { runAbortableProcess } from "../src/abortable_process.js";
 import { waitForPid } from "./helpers/wait_for_pid.js";
+import { nodeShellFixture } from "./helpers/node_shell_fixture.js";
 
 const run = promisify(execFile);
 const large = 10 * 1024 * 1024 + 1;
@@ -123,12 +124,11 @@ for (const mode of ["overflow", "interrupt", "host-handler", "once-handler", "ho
 			let wrapper: ReturnType<typeof spawn> | undefined;
 			let pid: number | undefined;
 			try {
-				const producer = path.join(dir, "producer.cjs"),
-					runner = path.join(dir, "runner.mjs");
+				const runner = path.join(dir, "runner.mjs");
 				const marker = path.join(dir, "pid"),
 					received = path.join(dir, "signal");
-				await writeFile(
-					producer,
+				const fixture = await nodeShellFixture(
+					dir,
 					`const fs=require('node:fs');
 process.on('SIGTERM',()=>{});
 process.on('SIGINT',()=>fs.writeFileSync(${quote(received)}, 'SIGINT'));
@@ -141,10 +141,11 @@ setInterval(()=>{${mode === "overflow" ? "process.stdout.write('x'.repeat(2048))
 ${mode === "host-handler" || mode === "once-handler" ? `process.${mode === "once-handler" ? "once" : "on"}('SIGINT',()=>console.log('host handled SIGINT'));` : ""}
 ${mode === "host-exit" ? "process.on('SIGUSR2',()=>process.exit(0));" : ""}
 const result=await new Lobster({env:{...process.env,LOBSTER_MAX_OUTPUT_BYTES:'1024'}})
-.pipe(exec(${quote(`${quote(process.execPath)} ${quote(producer)} & wait`)},{shell:true,json:false})).run();
+.pipe(exec(${quote(`${fixture.command} & wait`)},{shell:true,json:false})).run();
 console.log(JSON.stringify(result));`,
 				);
 				wrapper = spawn(process.execPath, [runner], {
+					env: { ...process.env, ...fixture.env },
 					detached: true,
 					stdio: ["ignore", "pipe", "pipe"],
 				});

--- a/test/sdk_exec.test.ts
+++ b/test/sdk_exec.test.ts
@@ -1,9 +1,10 @@
 import test from "node:test";
 import { waitForPid } from "./helpers/wait_for_pid.js";
+import { nodeShellFixture } from "./helpers/node_shell_fixture.js";
 import assert from "node:assert/strict";
 import { getEventListeners } from "node:events";
 import { spawnSync } from "node:child_process";
-import { access, mkdtemp, rm } from "node:fs/promises";
+import { access, mkdir, mkdtemp, realpath, rm, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -19,13 +20,11 @@ function quote(value: string) {
 	return JSON.stringify(value);
 }
 
-function longChildCommand() {
-	const script = [
-		'require("node:fs").writeFileSync(process.env.LOBSTER_EXEC_PID_FILE, String(process.pid));',
-		"setTimeout(() => {}, 30000);",
-	].join("");
-	return `${quote(process.execPath)} -e ${quote(script)}`;
-}
+const longChildScript = [
+	'require("node:fs").writeFileSync(process.env.LOBSTER_EXEC_PID_FILE, String(process.pid));',
+	"setTimeout(() => {}, 30000);",
+].join("");
+const longChildCommand = () => `${quote(process.execPath)} -e ${quote(longChildScript)}`;
 
 function processIsRunning(pid: number) {
 	assert.ok(Number.isSafeInteger(pid) && pid > 0, `Invalid child PID: ${pid}`);
@@ -50,11 +49,16 @@ async function waitUntilStopped(pid: number, timeoutMs = 2000) {
 	throw new Error(`Child ${pid} was still running after abort`);
 }
 
-async function runAbortableStage(stage: ReturnType<typeof exec>, signal: AbortSignal, cwd: string) {
+async function runAbortableStage(
+	stage: ReturnType<typeof exec>,
+	signal: AbortSignal,
+	cwd: string,
+	env: NodeJS.ProcessEnv = {},
+) {
 	return stage.run({
 		input: emptyInput(),
 		ctx: {
-			env: { ...process.env, LOBSTER_EXEC_PID_FILE: join(cwd, "pid") },
+			env: { ...process.env, ...env, LOBSTER_EXEC_PID_FILE: join(cwd, "pid") },
 			cwd,
 			signal,
 		},
@@ -86,10 +90,12 @@ test("sdk shell abort signal kills a long-running child", async () => {
 	try {
 		const pidFile = join(dir, "pid");
 		const controller = new AbortController();
+		const fixture = await nodeShellFixture(dir, longChildScript);
 		const pending = runAbortableStage(
-			shell(longChildCommand(), { json: false }),
+			shell(fixture.command, { json: false }),
 			controller.signal,
 			dir,
+			fixture.env,
 		);
 		const pid = await waitForPid(pidFile);
 		assert.equal(processIsRunning(pid), true);
@@ -131,12 +137,13 @@ for (const entry of ["clone", "resume"] as const) {
 		let pending: Promise<any> | undefined;
 		try {
 			const pidFile = join(dir, "pid");
+			const fixture = await nodeShellFixture(dir, longChildScript);
 			const workflow = new Lobster({
-				env: { ...process.env, LOBSTER_EXEC_PID_FILE: pidFile },
+				env: { ...process.env, ...fixture.env, LOBSTER_EXEC_PID_FILE: pidFile },
 				signal: controller.signal,
 			});
 			if (entry === "resume") workflow.pipe(approve());
-			workflow.pipe(exec(longChildCommand(), { shell: true, json: false }));
+			workflow.pipe(exec(fixture.command, { shell: true, json: false }));
 			if (entry === "resume") {
 				const first = await workflow.run();
 				assert.equal(first.status, "needs_approval");
@@ -178,22 +185,76 @@ test("pre-aborted SDK exec never starts a child", async () => {
 	}
 });
 
-test("SDK exec preserves output and failure handling and releases abort listeners", async () => {
-	const controller = new AbortController();
-	const run = (command: string) =>
-		new Lobster({ signal: controller.signal }).pipe(exec(command)).run();
-	const success = await run(`${quote(process.execPath)} -e ${quote('console.log("[1,2]")')}`);
-	assert.deepEqual(success.output, [1, 2]);
-	const failed = await run(
-		`${quote(process.execPath)} -e ${quote('console.error("failed");process.exit(7)')}`,
-	);
-	assert.equal(failed.ok, false);
-	assert.match(failed.error.message, /exited with code 7: failed/);
-	const missing = await run("lobster-nonexistent-executable-for-test");
-	assert.equal(missing.ok, false);
-	assert.match(missing.error.message, /Failed to execute .* ENOENT/);
-	assert.equal(getEventListeners(controller.signal, "abort").length, 0);
-});
+for (const useShell of [false, true]) {
+	test(`SDK ${useShell ? "shell" : "exec"} preserves output, failures, and listener cleanup`, async () => {
+		const dir = await mkdtemp(join(tmpdir(), "lobster-sdk-result-"));
+		const controller = new AbortController();
+		try {
+			const run = async (script: string) => {
+				const fixture = useShell ? await nodeShellFixture(dir, script) : undefined;
+				return new Lobster({
+					env: { ...process.env, ...fixture?.env },
+					signal: controller.signal,
+				})
+					.pipe(
+						exec(fixture?.command ?? `${quote(process.execPath)} -e ${quote(script)}`, {
+							shell: useShell,
+						}),
+					)
+					.run();
+			};
+			const success = await run('console.log("[1,2]")');
+			assert.deepEqual(success.output, [1, 2]);
+			const failed = await run('console.error("failed");process.exit(7)');
+			assert.equal(failed.ok, false);
+			assert.match(failed.error.message, /exited with code 7: failed/);
+			const missing = await new Lobster({
+				env: { ...process.env, LOBSTER_SHELL: "lobster-nonexistent-executable-for-test" },
+				signal: controller.signal,
+			})
+				.pipe(exec("lobster-nonexistent-executable-for-test", { shell: useShell }))
+				.run();
+			assert.equal(missing.ok, false);
+			assert.match(
+				missing.error.message,
+				useShell
+					? /exec shell not found; check LOBSTER_SHELL or ComSpec/
+					: /Failed to execute .* ENOENT/,
+			);
+			assert.equal(getEventListeners(controller.signal, "abort").length, 0);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+}
+
+test(
+	"SDK shell fixtures preserve literal $() in executable and script paths",
+	{ skip: process.platform === "win32" },
+	async () => {
+		const dir = await mkdtemp(join(tmpdir(), "lobster-sdk-shell-path-"));
+		try {
+			const fixtureDir = join(dir, "script $(touch marker)");
+			await mkdir(fixtureDir);
+			const executable = join(dir, "node $(touch marker)");
+			await symlink(process.execPath, executable);
+			const fixture = await nodeShellFixture(
+				fixtureDir,
+				"console.log(JSON.stringify([__filename]));",
+			);
+			const result = await new Lobster({
+				env: { ...process.env, ...fixture.env, LOBSTER_TEST_NODE: executable },
+			})
+				.pipe(shell(fixture.command, { cwd: dir }))
+				.run();
+			assert.equal(result.ok, true);
+			assert.deepEqual(result.output, [await realpath(fixture.env.LOBSTER_TEST_SCRIPT)]);
+			await assert.rejects(access(join(dir, "marker")), { code: "ENOENT" });
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	},
+);
 
 test("exported SDK runPipeline keeps signal optional and forwards supplied signals", async () => {
 	const controller = new AbortController();


### PR DESCRIPTION
SDK shell calls were being resolved inside the SDK and sent through the shared runner's direct-executable path. This change sends shell calls through `shellCommand` and leaves direct calls on `command`/`argv`, so shell selection and process lifecycle have one owner.

Cancellation, output caps, and JSON results keep their existing behavior. Missing-shell errors now identify `LOBSTER_SHELL`/`ComSpec`; shell exit errors identify the requested command. Environment-backed test fixtures preserve literal executable and script paths containing shell metacharacters.

Validation at `d939f5a3593620267814690a5039e58c1fab97c7`:
- [CI](https://github.com/openclaw/lobster/actions/runs/34289795470) and [CodeQL](https://github.com/openclaw/lobster/actions/runs/34289792550) passed.
- Fresh isolated AWS Linux execution on Node 24.20.0 and pnpm 12.3.4: frozen install, build, typecheck, lint, and all 635 tests passed with zero skips.
- Real SDK integration preserved literal `$()` paths/arguments without creating a substitution marker, verified shell exit/missing-shell errors, and confirmed cancellation terminated the child before returning.
- The built CLI returned `ok: true`, `status: "ok"`, and `output: [1,2,3]` for a direct `exec --json` command.
- macOS suite: 632 passed, 3 platform skips, zero failures. Independent branch autoreview through P2: scoped-clean.

The requested separate Linux proof is complete. The validation runner used a fresh PR checkout, no IAM instance role, no Actions hydration, and an isolated runtime environment. Seven existing lint warnings remain in unchanged files.

Related: https://github.com/openclaw/lobster/security/code-scanning/11. No alert dismissal is requested.

