### PR TITLE
test(pipeline): cover resume-state load validation branches

### DIFF
--- a/test/pipeline_resume_state.test.ts
+++ b/test/pipeline_resume_state.test.ts
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtempSync } from "node:fs";
+import { writeStateJson } from "../src/state/store.js";
+import { loadPipelineResumeState, type PipelineResumeState } from "../src/pipeline_resume_state.js";
+
+function stateDir() {
+	return { LOBSTER_STATE_DIR: mkdtempSync(path.join(os.tmpdir(), "lobster-pipeline-resume-")) };
+}
+
+function validApprovalState(): PipelineResumeState {
+	return {
+		pipeline: [{ name: "map", args: {}, raw: "map" }],
+		resumeAtIndex: 1,
+		items: [{ n: 1 }],
+		haltType: "approval_request",
+		prompt: "approve?",
+		createdAt: "2026-01-01T00:00:00.000Z",
+	};
+}
+
+async function loadStored(value: unknown) {
+	const env = stateDir();
+	await writeStateJson({ env, key: "resume", value });
+	return loadPipelineResumeState(env, "resume");
+}
+
+test("loadPipelineResumeState rejects a pipeline stage without a name", async () => {
+	await assert.rejects(
+		() => loadStored({ ...validApprovalState(), pipeline: [{ args: {}, raw: "map" }] }),
+		/Invalid pipeline resume state/,
+	);
+});
+
+test("loadPipelineResumeState rejects a pipeline stage whose args is an array", async () => {
+	await assert.rejects(
+		() =>
+			loadStored({ ...validApprovalState(), pipeline: [{ name: "map", args: [], raw: "map" }] }),
+		/Invalid pipeline resume state/,
+	);
+});
+
+test("loadPipelineResumeState rejects a resume index past the pipeline length", async () => {
+	await assert.rejects(
+		() => loadStored({ ...validApprovalState(), resumeAtIndex: 2 }),
+		/Invalid pipeline resume state/,
+	);
+});
+
+test("loadPipelineResumeState rejects a negative resume index", async () => {
+	await assert.rejects(
+		() => loadStored({ ...validApprovalState(), resumeAtIndex: -1 }),
+		/Invalid pipeline resume state/,
+	);
+});
+
+test("loadPipelineResumeState rejects non-array items", async () => {
+	await assert.rejects(
+		() => loadStored({ ...validApprovalState(), items: "nope" }),
+		/Invalid pipeline resume state/,
+	);
+});
+
+test("loadPipelineResumeState rejects superseded keys that are not strings", async () => {
+	await assert.rejects(
+		() => loadStored({ ...validApprovalState(), supersededResumeStateKeys: [1] }),
+		/Invalid pipeline resume state/,
+	);
+});
+
+test("loadPipelineResumeState rejects an unrecognized halt type", async () => {
+	await assert.rejects(
+		() => loadStored({ ...validApprovalState(), haltType: "other" }),
+		/Invalid pipeline resume state/,
+	);
+});
+
+test("loadPipelineResumeState rejects an unrecognized resume mode", async () => {
+	await assert.rejects(
+		() => loadStored({ ...validApprovalState(), resumeMode: "sideways" }),
+		/Invalid pipeline resume state/,
+	);
+});
+
+test("loadPipelineResumeState rejects an input request without a schema", async () => {
+	await assert.rejects(
+		() =>
+			loadStored({
+				...validApprovalState(),
+				items: [],
+				haltType: "input_request",
+				resumeMode: "next_stage",
+				prompt: "enter",
+			}),
+		/Invalid pipeline resume state/,
+	);
+});
+
+test("loadPipelineResumeState rejects command input outside a same-stage input resume", async () => {
+	await assert.rejects(
+		() => loadStored({ ...validApprovalState(), commandInput: { history: [] } }),
+		/Invalid pipeline resume state/,
+	);
+});

--- a/test/pipeline_resume_state.test.ts
+++ b/test/pipeline_resume_state.test.ts
@@ -2,13 +2,9 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtempSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
 import { writeStateJson } from "../src/state/store.js";
 import { loadPipelineResumeState, type PipelineResumeState } from "../src/pipeline_resume_state.js";
-
-function stateDir() {
-	return { LOBSTER_STATE_DIR: mkdtempSync(path.join(os.tmpdir(), "lobster-pipeline-resume-")) };
-}
 
 function validApprovalState(): PipelineResumeState {
 	return {
@@ -22,9 +18,14 @@ function validApprovalState(): PipelineResumeState {
 }
 
 async function loadStored(value: unknown) {
-	const env = stateDir();
-	await writeStateJson({ env, key: "resume", value });
-	return loadPipelineResumeState(env, "resume");
+	const dir = await mkdtemp(path.join(os.tmpdir(), "lobster-pipeline-resume-"));
+	const env = { LOBSTER_STATE_DIR: dir };
+	try {
+		await writeStateJson({ env, key: "resume", value });
+		return await loadPipelineResumeState(env, "resume");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
 }
 
 test("loadPipelineResumeState rejects a pipeline stage without a name", async () => {


### PR DESCRIPTION
Add ten focused tests for malformed saved pipeline state: missing stage names, array-valued stage args, out-of-range or negative resume indexes, non-array items, non-string superseded keys, unknown halt types or resume modes, missing input schemas, and misplaced command-input state.

Each fixture changes one field of an otherwise valid state and exercises the disk-backed loader. The maintainer follow-up removes each temporary directory in a `finally` block, including on rejection. Production behavior is unchanged.

Validation at `5eb57d80f4a7a2a08d3fd77890ddac308d5e9f89`:
- [Exact-head CI](https://github.com/openclaw/lobster/actions/runs/34656186831) passed.
- `pnpm build`, `pnpm typecheck`, `pnpm lint`, and `pnpm test` passed on Node 24.20.0: 640 passing tests, 3 platform skips, zero failures.
- Real built CLI: a valid `ask --emit` input resume executed a temporary downstream marker command; all ten corresponding corrupt-state variants returned `Invalid pipeline resume state` and never created the marker.
- Independent branch autoreview through P2: scoped-clean.

Contributor credit is preserved. The changelog entry is centralized in #165 to keep the independent PRs conflict-free.

